### PR TITLE
Issue #147: use static file-local helpers where appropriate

### DIFF
--- a/modules/echo/module.cpp
+++ b/modules/echo/module.cpp
@@ -9,7 +9,7 @@
 #include <memory>
 #include <string>
 
-std::string trim(const std::string &input)
+static std::string trim(const std::string &input)
 {
     const auto begin = std::find_if_not(input.begin(), input.end(), [](unsigned char c) {
         return std::isspace(c) != 0;

--- a/modules/proxy/module.cpp
+++ b/modules/proxy/module.cpp
@@ -15,7 +15,7 @@
 #include <string_view>
 #include <vector>
 
-std::string trim(const std::string &input)
+static std::string trim(const std::string &input)
 {
     const auto begin = std::find_if_not(input.begin(), input.end(), [](unsigned char c) {
         return std::isspace(c) != 0;
@@ -29,7 +29,7 @@ std::string trim(const std::string &input)
     return std::string(begin, end);
 }
 
-std::vector<std::string> splitTokens(const std::string &line)
+static std::vector<std::string> splitTokens(const std::string &line)
 {
     std::vector<std::string> tokens;
     std::string current;
@@ -61,12 +61,12 @@ std::vector<std::string> splitTokens(const std::string &line)
     return tokens;
 }
 
-std::string proxyError(std::string_view operation, std::string_view detail)
+static std::string proxyError(std::string_view operation, std::string_view detail)
 {
     return std::string("module-gui-proxy ") + std::string(operation) + ": " + std::string(detail);
 }
 
-void writeProxyError(
+static void writeProxyError(
     const grav_frontend::ErrorBufferView &errorBuffer,
     std::string_view operation,
     std::string_view detail)
@@ -82,12 +82,12 @@ struct GuiProxyState {
     grav_platform::ProcessHandle frontendProcess;
 };
 
-bool isRunning(const GuiProxyState &state)
+static bool isRunning(const GuiProxyState &state)
 {
     return state.frontendProcess.isRunning();
 }
 
-bool stopProcess(GuiProxyState &state, const grav_frontend::ErrorBufferView &errorBuffer)
+static bool stopProcess(GuiProxyState &state, const grav_frontend::ErrorBufferView &errorBuffer)
 {
     std::string processError;
     if (!state.frontendProcess.terminate(2000u, processError)) {
@@ -98,7 +98,7 @@ bool stopProcess(GuiProxyState &state, const grav_frontend::ErrorBufferView &err
     return true;
 }
 
-std::vector<std::string> frontendLaunchArgs(const GuiProxyState &state)
+static std::vector<std::string> frontendLaunchArgs(const GuiProxyState &state)
 {
     return {
         "--config",
@@ -112,7 +112,7 @@ std::vector<std::string> frontendLaunchArgs(const GuiProxyState &state)
     };
 }
 
-bool launchProcess(
+static bool launchProcess(
     GuiProxyState &state,
     const std::string &frontendExecutable,
     const grav_frontend::ErrorBufferView &errorBuffer)
@@ -134,12 +134,12 @@ bool launchProcess(
     return true;
 }
 
-std::string runningCommandLine(const GuiProxyState &state)
+static std::string runningCommandLine(const GuiProxyState &state)
 {
     return state.frontendProcess.commandLine();
 }
 
-std::string runningPidLabel(const GuiProxyState &state)
+static std::string runningPidLabel(const GuiProxyState &state)
 {
     if (!state.frontendProcess.isRunning()) {
         return {};
@@ -147,7 +147,7 @@ std::string runningPidLabel(const GuiProxyState &state)
     return state.frontendProcess.pidString();
 }
 
-bool parseUnsignedPort(std::string_view raw, std::uint16_t &outPort)
+static bool parseUnsignedPort(std::string_view raw, std::uint16_t &outPort)
 {
     const std::string trimmed = trim(std::string(raw));
     if (trimmed.empty()) {
@@ -169,7 +169,7 @@ bool parseUnsignedPort(std::string_view raw, std::uint16_t &outPort)
     return true;
 }
 
-void printHelp()
+static void printHelp()
 {
     std::cout
         << "[module-gui-proxy] commands:\n"
@@ -181,7 +181,7 @@ void printHelp()
         << "  stop\n";
 }
 
-bool parseBool(std::string_view raw, bool &out)
+static bool parseBool(std::string_view raw, bool &out)
 {
     std::string value(raw);
     std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {

--- a/modules/qt/module.cpp
+++ b/modules/qt/module.cpp
@@ -36,7 +36,7 @@
 #include <unistd.h>
 #endif
 
-bool parseBool(std::string_view raw, bool &out)
+static bool parseBool(std::string_view raw, bool &out)
 {
     std::string value(raw);
     std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
@@ -53,7 +53,7 @@ bool parseBool(std::string_view raw, bool &out)
     return false;
 }
 
-std::string trim(const std::string &input)
+static std::string trim(const std::string &input)
 {
     const auto begin = std::find_if_not(input.begin(), input.end(), [](unsigned char c) {
         return std::isspace(c) != 0;
@@ -67,7 +67,7 @@ std::string trim(const std::string &input)
     return std::string(begin, end);
 }
 
-std::vector<std::string> splitTokens(const std::string &line)
+static std::vector<std::string> splitTokens(const std::string &line)
 {
     std::vector<std::string> tokens;
     std::string current;
@@ -116,7 +116,7 @@ struct QtInProcState {
     std::mutex startupMutex;
 };
 
-std::string currentExecutablePath()
+static std::string currentExecutablePath()
 {
 #if defined(_WIN32)
     std::vector<char> buffer(4096u, '\0');
@@ -143,7 +143,7 @@ std::string currentExecutablePath()
 #endif
 }
 
-void configureQtPluginPathFallback()
+static void configureQtPluginPathFallback()
 {
     QString pluginRoot;
     const std::string exePath = currentExecutablePath();
@@ -170,7 +170,7 @@ void configureQtPluginPathFallback()
     qputenv("QT_PLUGIN_PATH", pluginRoot.toUtf8());
 }
 
-void qtThreadMain(QtInProcState *state)
+static void qtThreadMain(QtInProcState *state)
 {
     try {
         int argc = 1;
@@ -214,7 +214,7 @@ void qtThreadMain(QtInProcState *state)
     state->running.store(false);
 }
 
-bool startQtUi(QtInProcState &state, const grav_frontend::ErrorBufferView &errorBuffer)
+static bool startQtUi(QtInProcState &state, const grav_frontend::ErrorBufferView &errorBuffer)
 {
     if (state.uiThread.joinable() || state.running.load()) {
         return true;
@@ -246,7 +246,7 @@ bool startQtUi(QtInProcState &state, const grav_frontend::ErrorBufferView &error
     return true;
 }
 
-void stopQtUi(QtInProcState &state)
+static void stopQtUi(QtInProcState &state)
 {
     if (state.uiThread.joinable()) {
         QCoreApplication *app = QCoreApplication::instance();
@@ -258,7 +258,7 @@ void stopQtUi(QtInProcState &state)
     state.running.store(false);
 }
 
-void printHelp()
+static void printHelp()
 {
     std::cout
         << "[module-qt] commands:\n"

--- a/runtime/src/frontend/FrontendModuleHandleLoad.cpp
+++ b/runtime/src/frontend/FrontendModuleHandleLoad.cpp
@@ -11,7 +11,7 @@
 
 namespace grav_module {
 
-bool hasRequiredExports(const FrontendModuleExportsV1 *exports)
+static bool hasRequiredExports(const FrontendModuleExportsV1 *exports)
 {
     return exports != nullptr
         && exports->apiVersion == kFrontendModuleApiVersionV1


### PR DESCRIPTION
## IV&V Checklist

- [ ] Analyzer evidence attached
- [x] Deterministic test evidence attached
- [ ] Independent reviewer identified
- [x] Deviation recorded or not needed

Independent reviewer: @reviewer
Analyzer evidence: not run locally
Deterministic test evidence: `python tests/checks/check.py all --root . --config simulation.ini`; `cmake --build build-issue-145 --target myAppModuleHost gravityFrontendModuleEcho gravityFrontendModuleGuiProxy gravityFrontendModuleQtInProc --parallel`
Deviation: not needed

## Traceability

Requirements impacted:
- REQ-MOD-001
- REQ-MOD-002

## Notes

Implements #147

Closes #147
