### PR TITLE
Issue #15: expose configurable backend substep policy

### DIFF
--- a/docs/quality/manifest/requirements.json
+++ b/docs/quality/manifest/requirements.json
@@ -82,7 +82,7 @@
       "tests": [
         "^ClientBridgeTest\\.TST_INT_RUNT_00[1-2]_",
         "^ClientRuntimeTest\\.TST_CNT_RUNT_00[1-8]_",
-        "^PhysicsTest\\.TST_UNT_RUNT_00[1-3]_"
+        "^PhysicsTest\\.TST_UNT_RUNT_00[1-4]_"
       ]
     },
     "REQ-PHYS-001": {

--- a/docs/quality/manifest/test_groups_core.json
+++ b/docs/quality/manifest/test_groups_core.json
@@ -363,6 +363,12 @@
         "req_ids": [
           "REQ-RUN-001"
         ]
+      },
+      "TST-UNT-RUNT-004": {
+        "id": "PhysicsTest.TST_UNT_RUNT_004_ServerAppliesConfiguredSubstepPolicy",
+        "req_ids": [
+          "REQ-RUN-001"
+        ]
       }
     },
     "EVD_TEST_INT_UI_QT_WINDOW": {

--- a/engine/include/config/SimulationConfig.hpp
+++ b/engine/include/config/SimulationConfig.hpp
@@ -11,6 +11,8 @@ struct SimulationConfig {
     float dt = 0.01f;
     std::string solver = "pairwise_cuda";
     std::string integrator = "euler";
+    float substepTargetDt = 0.0f;
+    std::uint32_t maxSubsteps = 32u;
     float octreeTheta = 1.2f;
     float octreeSoftening = 2.5f;
     std::uint32_t clientParticleCap = grav_protocol::kSnapshotMaxPoints;

--- a/engine/include/server/SimulationServer.hpp
+++ b/engine/include/server/SimulationServer.hpp
@@ -91,6 +91,11 @@ class SimulationServer : public grav_client::ILocalServer {
         std::atomic<bool> _energyEstimated;
         std::atomic<std::uint32_t> _energyMeasureEverySteps;
         std::atomic<std::uint32_t> _energySampleLimit;
+        std::atomic<float> _configuredSubstepTargetDt;
+        std::atomic<std::uint32_t> _configuredMaxSubsteps;
+        std::atomic<float> _lastAppliedSubstepTargetDt;
+        std::atomic<float> _lastAppliedSubstepDt;
+        std::atomic<std::uint32_t> _lastAppliedSubsteps;
         std::atomic<bool> _faulted;
         std::atomic<std::uint64_t> _faultStep;
 

--- a/engine/include/types/SimulationTypes.hpp
+++ b/engine/include/types/SimulationTypes.hpp
@@ -49,6 +49,10 @@ struct SimulationStats {
     std::string faultReason;
     bool sphEnabled;
     float serverFps;
+    float substepTargetDt;
+    float substepDt;
+    std::uint32_t substeps;
+    std::uint32_t maxSubsteps;
     std::uint32_t particleCount;
     float kineticEnergy;
     float potentialEnergy;

--- a/engine/src/config/SimulationConfig.cpp
+++ b/engine/src/config/SimulationConfig.cpp
@@ -89,6 +89,10 @@ bool SimulationConfig::save(const std::string &path) const
     out << "solver=" << solver << "\n";
     out << "# Time integrator: euler | rk4 (octree_gpu supports euler only)\n";
     out << "integrator=" << integrator << "\n";
+    out << "# Internal substep target dt. 0 uses auto policy based on solver/integrator/SPH.\n";
+    out << "substep_target_dt=" << substepTargetDt << "\n";
+    out << "# Hard cap applied to per-step substep splitting.\n";
+    out << "max_substeps=" << std::max<std::uint32_t>(1u, maxSubsteps) << "\n";
     out << "\n";
 
     out << "# [Octree]\n";

--- a/engine/src/config/SimulationOptionRegistryEntries.cpp
+++ b/engine/src/config/SimulationOptionRegistryEntries.cpp
@@ -9,6 +9,8 @@ const SimulationOptionEntry kSimulationOptions[] = {
     {SimulationOptionGroup::Core, OptionKind::Float, "--dt", "", "dt", "", "", "  --dt <float>\n", "", offsetof(SimulationConfig, dt), 0.000001, 0.0, true, false},
     {SimulationOptionGroup::Core, OptionKind::Solver, "--solver", "", "solver", "", "", "  --solver <pairwise_cuda|octree_gpu|octree_cpu>\n", "", offsetof(SimulationConfig, solver), 0.0, 0.0, false, false},
     {SimulationOptionGroup::Core, OptionKind::Integrator, "--integrator", "", "integrator", "", "", "  --integrator <euler|rk4>\n", "", offsetof(SimulationConfig, integrator), 0.0, 0.0, false, false},
+    {SimulationOptionGroup::Core, OptionKind::Float, "--substep-target-dt", "", "substep_target_dt", "", "", "  --substep-target-dt <float|0=auto>\n", "", offsetof(SimulationConfig, substepTargetDt), 0.0, 0.0, true, false},
+    {SimulationOptionGroup::Core, OptionKind::Uint, "--max-substeps", "", "max_substeps", "", "", "  --max-substeps <n>\n", "", offsetof(SimulationConfig, maxSubsteps), 1.0, 1024.0, true, true},
     {SimulationOptionGroup::Core, OptionKind::Float, "--octree-theta", "", "octree_theta", "", "", "  --octree-theta <float>\n", "", offsetof(SimulationConfig, octreeTheta), 0.01, 0.0, true, false},
     {SimulationOptionGroup::Core, OptionKind::Float, "--octree-softening", "", "octree_softening", "", "", "  --octree-softening <float>\n", "", offsetof(SimulationConfig, octreeSoftening), 0.000001, 0.0, true, false},
     {SimulationOptionGroup::Core, OptionKind::ClientParticleCap, "--client-particle-cap", "", "client_particle_cap", "", "GRAVITY_CLIENT_DRAW_CAP", "  --client-particle-cap <n>\n", "", offsetof(SimulationConfig, clientParticleCap), 0.0, 0.0, false, false},

--- a/engine/src/server/SimulationServer.cpp
+++ b/engine/src/server/SimulationServer.cpp
@@ -156,12 +156,37 @@ bool coerceConfigSolverIntegratorCompatibility(std::string &solver, std::string 
     return false;
 }
 
+float autoTargetSubstepDt(std::string_view solver, bool eulerIntegrator, bool sphEnabled, std::size_t liveParticleCount)
+{
+    if (sphEnabled) {
+        return 0.001f;
+    }
+    if (!eulerIntegrator) {
+        return 0.0025f;
+    }
+    if (liveParticleCount >= 100'000u) {
+        return 0.01f;
+    }
+    if (liveParticleCount >= 20'000u) {
+        return 0.005f;
+    }
+    if (solver == grav_modes::kSolverOctreeGpu) {
+        return 0.0025f;
+    }
+    if (solver == grav_modes::kSolverOctreeCpu) {
+        return 0.001f;
+    }
+    return 0.0005f;
+}
+
 void logEffectiveExecutionModes(
     std::string_view solver,
     std::string_view integrator,
     float theta,
     float softening,
-    bool sphEnabled)
+    bool sphEnabled,
+    float configuredSubstepTargetDt,
+    std::uint32_t configuredMaxSubsteps)
 {
     std::cout << "[server] active solver=" << solver
               << " integrator=" << integrator;
@@ -169,7 +194,9 @@ void logEffectiveExecutionModes(
         std::cout << " theta=" << theta
                   << " softening=" << softening;
     }
-    std::cout << " sph=" << (sphEnabled ? "on" : "off") << "\n";
+    std::cout << " sph=" << (sphEnabled ? "on" : "off")
+              << " substep_target_dt=" << configuredSubstepTargetDt
+              << " max_substeps=" << configuredMaxSubsteps << "\n";
 }
 
 std::string defaultExportPath(const std::string &directory, const std::string &format, std::uint64_t step)
@@ -970,6 +997,11 @@ SimulationServer::SimulationServer(std::uint32_t particleCount, float initialDt)
       _energyEstimated(false),
       _energyMeasureEverySteps(30),
       _energySampleLimit(5000),
+      _configuredSubstepTargetDt(0.0f),
+      _configuredMaxSubsteps(32u),
+      _lastAppliedSubstepTargetDt(0.0f),
+      _lastAppliedSubstepDt(0.0f),
+      _lastAppliedSubsteps(0u),
       _faulted(false),
       _faultStep(0),
       _particleCount(std::max<std::uint32_t>(2u, particleCount)),
@@ -1006,6 +1038,8 @@ SimulationServer::SimulationServer(std::uint32_t particleCount, float initialDt)
     _runtimeConfigMirror.dt = std::max(1e-6f, initialDt);
     _runtimeConfigMirror.solver = _solverMode;
     _runtimeConfigMirror.integrator = _integratorMode;
+    _runtimeConfigMirror.substepTargetDt = _configuredSubstepTargetDt.load(std::memory_order_relaxed);
+    _runtimeConfigMirror.maxSubsteps = _configuredMaxSubsteps.load(std::memory_order_relaxed);
     _runtimeConfigMirror.octreeTheta = _octreeTheta;
     _runtimeConfigMirror.octreeSoftening = _octreeSoftening;
     _runtimeConfigMirror.sphEnabled = _sphEnabled;
@@ -1058,6 +1092,8 @@ SimulationServer::SimulationServer(const std::string &configPath)
     _dt.store(std::max(1e-6f, loaded.dt), std::memory_order_relaxed);
     _energyMeasureEverySteps.store(std::max<std::uint32_t>(1u, loaded.energyMeasureEverySteps), std::memory_order_relaxed);
     _energySampleLimit.store(std::max<std::uint32_t>(64u, loaded.energySampleLimit), std::memory_order_relaxed);
+    _configuredSubstepTargetDt.store(std::max(0.0f, loaded.substepTargetDt), std::memory_order_relaxed);
+    _configuredMaxSubsteps.store(std::max<std::uint32_t>(1u, loaded.maxSubsteps), std::memory_order_relaxed);
 }
 
 SimulationServer::~SimulationServer()
@@ -1361,6 +1397,10 @@ SimulationStats SimulationServer::getStats() const
         std::move(faultReason),
         sphEnabled,
         _serverFps.load(std::memory_order_relaxed),
+        _lastAppliedSubstepTargetDt.load(std::memory_order_relaxed),
+        _lastAppliedSubstepDt.load(std::memory_order_relaxed),
+        _lastAppliedSubsteps.load(std::memory_order_relaxed),
+        _configuredMaxSubsteps.load(std::memory_order_relaxed),
         particleCount,
         _kineticEnergy.load(std::memory_order_relaxed),
         _potentialEnergy.load(std::memory_order_relaxed),
@@ -1395,8 +1435,10 @@ SimulationConfig SimulationServer::getRuntimeConfig() const
         config.inputFile = _initialStatePath;
         config.inputFormat = _initialStateFormat;
     }
-    config.dt = _dt.load(std::memory_order_relaxed);
-    config.energyMeasureEverySteps = _energyMeasureEverySteps.load(std::memory_order_relaxed);
+        config.dt = _dt.load(std::memory_order_relaxed);
+        config.substepTargetDt = _configuredSubstepTargetDt.load(std::memory_order_relaxed);
+        config.maxSubsteps = _configuredMaxSubsteps.load(std::memory_order_relaxed);
+        config.energyMeasureEverySteps = _energyMeasureEverySteps.load(std::memory_order_relaxed);
     config.energySampleLimit = _energySampleLimit.load(std::memory_order_relaxed);
     return config;
 }
@@ -1592,7 +1634,14 @@ void SimulationServer::rebuildSystem()
         initConfig.thermalHeatingCoeff,
         initConfig.thermalRadiationCoeff
     );
-    logEffectiveExecutionModes(effectiveSolver, integrator, theta, softening, sphEnabled);
+    logEffectiveExecutionModes(
+        effectiveSolver,
+        integrator,
+        theta,
+        softening,
+        sphEnabled,
+        _configuredSubstepTargetDt.load(std::memory_order_relaxed),
+        _configuredMaxSubsteps.load(std::memory_order_relaxed));
     if (initConfig.thermalHeatingCoeff > 0.0f || initConfig.thermalRadiationCoeff > 0.0f) {
         std::cout << "[server] warning: thermal model active (heating="
                   << initConfig.thermalHeatingCoeff
@@ -1610,6 +1659,9 @@ void SimulationServer::rebuildSystem()
     _totalEnergy.store(0.0f, std::memory_order_relaxed);
     _energyDriftPct.store(0.0f, std::memory_order_relaxed);
     _energyEstimated.store(false, std::memory_order_relaxed);
+    _lastAppliedSubstepTargetDt.store(0.0f, std::memory_order_relaxed);
+    _lastAppliedSubstepDt.store(0.0f, std::memory_order_relaxed);
+    _lastAppliedSubsteps.store(0u, std::memory_order_relaxed);
     _hasEnergyBaseline = false;
     _energyBaseline = 0.0f;
     _faulted.store(false, std::memory_order_relaxed);
@@ -2047,18 +2099,28 @@ void SimulationServer::loop()
             const float dt = std::max(1e-6f, _dt.load(std::memory_order_relaxed));
             const std::size_t liveParticleCount = _system ? _system->getParticles().size() : 0u;
             const bool eulerIntegrator = _system->getIntegratorMode() == ParticleSystem::IntegratorMode::Euler;
-            const float targetSubstep = sphEnabled ? 0.001f : (eulerIntegrator ? 0.0002f : 0.0025f);
-            float adjustedTargetSubstep = targetSubstep;
-            if (!sphEnabled) {
-                if (liveParticleCount >= 100'000u) {
-                    adjustedTargetSubstep = std::max(adjustedTargetSubstep, 0.01f);
-                } else if (liveParticleCount >= 20'000u) {
-                    adjustedTargetSubstep = std::max(adjustedTargetSubstep, 0.005f);
-                }
-            }
-            std::uint32_t substeps = static_cast<std::uint32_t>(std::ceil(dt / adjustedTargetSubstep));
-            substeps = std::max<std::uint32_t>(1u, std::min<std::uint32_t>(substeps, 256u));
+            const float configuredTargetSubstepDt = _configuredSubstepTargetDt.load(std::memory_order_relaxed);
+            const float appliedTargetSubstepDt = configuredTargetSubstepDt > 0.0f
+                ? configuredTargetSubstepDt
+                : autoTargetSubstepDt(solverMode, eulerIntegrator, sphEnabled, liveParticleCount);
+            const std::uint32_t configuredMaxSubsteps = std::max<std::uint32_t>(
+                1u,
+                _configuredMaxSubsteps.load(std::memory_order_relaxed));
+            const std::uint32_t requiredSubsteps = std::max<std::uint32_t>(
+                1u,
+                static_cast<std::uint32_t>(std::ceil(dt / appliedTargetSubstepDt)));
+            const std::uint32_t substeps = std::min<std::uint32_t>(requiredSubsteps, configuredMaxSubsteps);
             const float dtSub = dt / static_cast<float>(substeps);
+            _lastAppliedSubstepTargetDt.store(appliedTargetSubstepDt, std::memory_order_relaxed);
+            _lastAppliedSubstepDt.store(dtSub, std::memory_order_relaxed);
+            _lastAppliedSubsteps.store(substeps, std::memory_order_relaxed);
+            if (requiredSubsteps > configuredMaxSubsteps && (_steps.load(std::memory_order_relaxed) % 256u) == 0u) {
+                std::cerr << "[server] substep clamp active dt=" << dt
+                          << " target_dt=" << appliedTargetSubstepDt
+                          << " required=" << requiredSubsteps
+                          << " max=" << configuredMaxSubsteps
+                          << " applied_dt=" << dtSub << "\n";
+            }
             for (std::uint32_t s = 0; s < substeps; ++s) {
                 if (!_system->update(dtSub)) {
                     updateFailed = true;

--- a/modules/cli/module_cli_server_ops.cpp
+++ b/modules/cli/module_cli_server_ops.cpp
@@ -66,6 +66,10 @@ public:
                   << " solver=" << status.solver << " integrator=" << status.integrator
                   << " sph=" << (status.sphEnabled ? "on" : "off")
                   << " sps=" << status.serverFps << " particles=" << status.particleCount
+                  << " substeps=" << status.substeps
+                  << " subdt=" << status.substepDt
+                  << " target=" << status.substepTargetDt
+                  << " max_substeps=" << status.maxSubsteps
                   << " Etot=" << status.totalEnergy << " dE=" << status.energyDriftPct
                   << " fault_step=" << status.faultStep
                   << (status.faultReason.empty() ? "" : " fault=\"" + status.faultReason + "\"")

--- a/modules/qt/ui/MainWindow.cpp
+++ b/modules/qt/ui/MainWindow.cpp
@@ -698,7 +698,7 @@ void MainWindow::tick()
     }
 
     _statusLabel->setText(
-        QString("state=%1 | link=%2 owner=%3 | solver=%4 integrator=%5 | sph=%6 | dt=%7 | server=%8 step/s | ui=%9 fps | steps=%10 | particles=%11 draw=%12 cap=%13 | data=stats:%14 snap:%15 %16 | Ekin=%17 Epot=%18 Eth=%19 Erad=%20 Etot=%21 | dE=%22%% %23")
+        QString("state=%1 | link=%2 owner=%3 | solver=%4 integrator=%5 | sph=%6 | dt=%7 | server=%8 step/s | sub=%9x@%10 (target=%11 max=%12) | ui=%13 fps | steps=%14 | particles=%15 draw=%16 cap=%17 | data=stats:%18 snap:%19 %20 | Ekin=%21 Epot=%22 Eth=%23 Erad=%24 Etot=%25 | dE=%26%% %27")
             .arg(stats.faulted ? "FAULT" : (stats.paused ? "PAUSED" : "RUNNING"))
             .arg(QString::fromStdString(linkLabel))
             .arg(QString::fromStdString(ownerLabel))
@@ -707,6 +707,10 @@ void MainWindow::tick()
             .arg(stats.sphEnabled ? "on" : "off")
             .arg(stats.dt, 0, 'f', 5)
             .arg(stats.serverFps, 0, 'f', 1)
+            .arg(stats.substeps)
+            .arg(stats.substepDt, 0, 'f', 5)
+            .arg(stats.substepTargetDt, 0, 'f', 5)
+            .arg(stats.maxSubsteps)
             .arg(_uiTickFps, 0, 'f', 1)
             .arg(static_cast<qulonglong>(stats.steps))
             .arg(stats.particleCount)
@@ -742,6 +746,10 @@ void MainWindow::tick()
                   << " integrator=" << stats.integratorName
                   << " sph=" << (stats.sphEnabled ? "on" : "off")
                   << " step_s=" << stats.serverFps
+                  << " substeps=" << stats.substeps
+                  << " substep_dt=" << stats.substepDt
+                  << " substep_target_dt=" << stats.substepTargetDt
+                  << " max_substeps=" << stats.maxSubsteps
                   << " ui_fps=" << _uiTickFps
                   << " snapshot=" << snapshotSize
                   << " draw=" << displayedParticles

--- a/runtime/include/protocol/ServerClient.hpp
+++ b/runtime/include/protocol/ServerClient.hpp
@@ -22,6 +22,10 @@ struct ServerClientStatus {
     std::string faultReason;
     bool sphEnabled = false;
     float serverFps = 0.0f;
+    float substepTargetDt = 0.0f;
+    float substepDt = 0.0f;
+    std::uint32_t substeps = 0;
+    std::uint32_t maxSubsteps = 0;
     std::uint32_t particleCount = 0;
     std::string solver;
     std::string integrator;

--- a/runtime/include/protocol/ServerJsonCodec.hpp
+++ b/runtime/include/protocol/ServerJsonCodec.hpp
@@ -31,6 +31,10 @@ struct ServerStatusPayload {
     std::string faultReason;
     bool sphEnabled = false;
     float serverFps = 0.0f;
+    float substepTargetDt = 0.0f;
+    float substepDt = 0.0f;
+    std::uint32_t substeps = 0;
+    std::uint32_t maxSubsteps = 0;
     std::uint32_t particleCount = 0;
     std::string solver;
     std::string integrator;

--- a/runtime/src/client/ClientServerBridge.cpp
+++ b/runtime/src/client/ClientServerBridge.cpp
@@ -756,6 +756,10 @@ SimulationStats ClientServerBridge::fromRemoteStatus(const ServerClientStatus &s
     stats.faultReason = status.faultReason;
     stats.sphEnabled = status.sphEnabled;
     stats.serverFps = status.serverFps;
+    stats.substepTargetDt = status.substepTargetDt;
+    stats.substepDt = status.substepDt;
+    stats.substeps = status.substeps;
+    stats.maxSubsteps = status.maxSubsteps;
     stats.particleCount = status.particleCount;
     stats.kineticEnergy = status.kineticEnergy;
     stats.potentialEnergy = status.potentialEnergy;

--- a/runtime/src/protocol/ServerClient.cpp
+++ b/runtime/src/protocol/ServerClient.cpp
@@ -277,6 +277,10 @@ ServerClientResponse ServerClient::getStatus(ServerClientStatus &outStatus)
         outStatus.faultReason = parsed.faultReason;
         outStatus.sphEnabled = parsed.sphEnabled;
         outStatus.serverFps = parsed.serverFps;
+        outStatus.substepTargetDt = parsed.substepTargetDt;
+        outStatus.substepDt = parsed.substepDt;
+        outStatus.substeps = parsed.substeps;
+        outStatus.maxSubsteps = parsed.maxSubsteps;
         outStatus.particleCount = parsed.particleCount;
         outStatus.solver = parsed.solver;
         outStatus.integrator = parsed.integrator;

--- a/runtime/src/protocol/ServerJsonCodec.cpp
+++ b/runtime/src/protocol/ServerJsonCodec.cpp
@@ -78,6 +78,10 @@ std::string ServerJsonCodec::makeStatusResponse(const SimulationStats &stats)
         << ",\"fault_reason\":\"" << escapeString(stats.faultReason) << "\""
         << ",\"sph\":" << (stats.sphEnabled ? "true" : "false")
         << ",\"server_fps\":" << stats.serverFps
+        << ",\"substep_target_dt\":" << stats.substepTargetDt
+        << ",\"substep_dt\":" << stats.substepDt
+        << ",\"substeps\":" << stats.substeps
+        << ",\"max_substeps\":" << stats.maxSubsteps
         << ",\"particles\":" << stats.particleCount
         << ",\"solver\":\"" << escapeString(stats.solverName) << "\""
         << ",\"integrator\":\"" << escapeString(stats.integratorName) << "\""

--- a/runtime/src/protocol/ServerJsonCodecParseStatus.cpp
+++ b/runtime/src/protocol/ServerJsonCodecParseStatus.cpp
@@ -20,6 +20,10 @@ bool ServerJsonCodec::parseStatusResponse(std::string_view raw, ServerStatusPayl
     readString(raw, "fault_reason", parsed.faultReason);
     readBool(raw, "sph", parsed.sphEnabled);
     readNumber(raw, "server_fps", parsed.serverFps);
+    readNumber(raw, "substep_target_dt", parsed.substepTargetDt);
+    readNumber(raw, "substep_dt", parsed.substepDt);
+    readNumber(raw, "substeps", parsed.substeps);
+    readNumber(raw, "max_substeps", parsed.maxSubsteps);
     readNumber(raw, "particles", parsed.particleCount);
     readString(raw, "solver", parsed.solver);
     readString(raw, "integrator", parsed.integrator);

--- a/tests/unit/config/args_cli.cpp
+++ b/tests/unit/config/args_cli.cpp
@@ -41,13 +41,15 @@ TEST(ConfigArgsTest, TST_UNT_CONF_003_AppliesValidArguments)
     RuntimeArgs runtime;
     std::stringstream warnings;
     std::vector<std::string> args = {"app", "--particle-count", "2048", "--dt=0.02", "--solver", "octree_gpu", "--integrator", "euler",
-        "--sph", "true", "--target-steps", "333", "--export-on-exit=false", "--ui-fps", "75", "--energy-every", "2",
+        "--substep-target-dt", "0.005", "--max-substeps", "12", "--sph", "true", "--target-steps", "333", "--export-on-exit=false", "--ui-fps", "75", "--energy-every", "2",
         "--server-command-timeout-ms", "90", "--server-status-timeout-ms", "35", "--server-snapshot-timeout-ms", "180"};
     applyArgsToConfig(grav_test_config_args_cli::toArgViews(args), config, runtime, warnings);
     EXPECT_EQ(config.particleCount, 2048u);
     EXPECT_FLOAT_EQ(config.dt, 0.02f);
     EXPECT_EQ(config.solver, "octree_gpu");
     EXPECT_EQ(config.integrator, "euler");
+    EXPECT_FLOAT_EQ(config.substepTargetDt, 0.005f);
+    EXPECT_EQ(config.maxSubsteps, 12u);
     EXPECT_TRUE(config.sphEnabled);
     EXPECT_EQ(config.uiFpsLimit, 75u);
     EXPECT_EQ(config.energyMeasureEverySteps, 2u);

--- a/tests/unit/config/args_io.cpp
+++ b/tests/unit/config/args_io.cpp
@@ -18,6 +18,8 @@ TEST(ConfigArgsTest, TST_UNT_CONF_010_SimulationConfigSaveLoadRoundTrip)
     config.dt = 0.015f;
     config.solver = "octree_cpu";
     config.integrator = "rk4";
+    config.substepTargetDt = 0.004f;
+    config.maxSubsteps = 11u;
     config.sphEnabled = true;
     config.exportFormat = "bin";
     config.energySampleLimit = 777u;
@@ -33,6 +35,8 @@ TEST(ConfigArgsTest, TST_UNT_CONF_010_SimulationConfigSaveLoadRoundTrip)
     EXPECT_FLOAT_EQ(loaded.dt, config.dt);
     EXPECT_EQ(loaded.solver, config.solver);
     EXPECT_EQ(loaded.integrator, config.integrator);
+    EXPECT_FLOAT_EQ(loaded.substepTargetDt, config.substepTargetDt);
+    EXPECT_EQ(loaded.maxSubsteps, config.maxSubsteps);
     EXPECT_EQ(loaded.sphEnabled, config.sphEnabled);
     EXPECT_EQ(loaded.exportFormat, config.exportFormat);
     EXPECT_EQ(loaded.energySampleLimit, config.energySampleLimit);

--- a/tests/unit/physics/substep_policy.cpp
+++ b/tests/unit/physics/substep_policy.cpp
@@ -1,0 +1,60 @@
+#include "server/SimulationServer.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+#include <vector>
+
+namespace grav_test_substep_policy {
+
+static std::filesystem::path writeTempConfig()
+{
+    const std::filesystem::path path = std::filesystem::temp_directory_path() / "grav_substep_policy.ini";
+    std::ofstream out(path, std::ios::trunc);
+    out << "particle_count=32\n";
+    out << "dt=0.01\n";
+    out << "solver=octree_cpu\n";
+    out << "integrator=euler\n";
+    out << "substep_target_dt=0.005\n";
+    out << "max_substeps=8\n";
+    out << "init_config_style=preset\n";
+    out << "preset_structure=random_cloud\n";
+    out << "sph_enabled=false\n";
+    return path;
+}
+
+static bool waitForSteps(SimulationServer &server, std::uint64_t expectedSteps, int timeoutMs)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (server.getStats().steps >= expectedSteps) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    return server.getStats().steps >= expectedSteps;
+}
+
+TEST(PhysicsTest, TST_UNT_RUNT_004_ServerAppliesConfiguredSubstepPolicy)
+{
+    const std::filesystem::path configPath = writeTempConfig();
+    SimulationServer server(configPath.string());
+    server.start();
+
+    ASSERT_TRUE(waitForSteps(server, 1u, 4000));
+
+    const SimulationStats stats = server.getStats();
+    EXPECT_FLOAT_EQ(stats.substepTargetDt, 0.005f);
+    EXPECT_FLOAT_EQ(stats.substepDt, 0.005f);
+    EXPECT_EQ(stats.substeps, 2u);
+    EXPECT_EQ(stats.maxSubsteps, 8u);
+
+    server.stop();
+    std::error_code ec;
+    std::filesystem::remove(configPath, ec);
+}
+
+} // namespace grav_test_substep_policy

--- a/tests/unit/protocol/json_codec.cpp
+++ b/tests/unit/protocol/json_codec.cpp
@@ -36,6 +36,10 @@ TEST(ServerProtocolCodecTest, TST_UNT_PROT_002_ParsesTypedStatusPayload)
     stats.faultReason = "bad\\nstate";
     stats.sphEnabled = true;
     stats.serverFps = 144.5f;
+    stats.substepTargetDt = 0.0025f;
+    stats.substepDt = 0.00125f;
+    stats.substeps = 8u;
+    stats.maxSubsteps = 32u;
     stats.particleCount = 128u;
     stats.solverName = "octree_gpu";
     stats.integratorName = "euler";
@@ -61,6 +65,10 @@ TEST(ServerProtocolCodecTest, TST_UNT_PROT_002_ParsesTypedStatusPayload)
     EXPECT_EQ(parsed.faultReason, "bad\\nstate");
     EXPECT_TRUE(parsed.sphEnabled);
     EXPECT_FLOAT_EQ(parsed.serverFps, 144.5f);
+    EXPECT_FLOAT_EQ(parsed.substepTargetDt, 0.0025f);
+    EXPECT_FLOAT_EQ(parsed.substepDt, 0.00125f);
+    EXPECT_EQ(parsed.substeps, 8u);
+    EXPECT_EQ(parsed.maxSubsteps, 32u);
     EXPECT_EQ(parsed.particleCount, 128u);
     EXPECT_EQ(parsed.solver, "octree_gpu");
     EXPECT_EQ(parsed.integrator, "euler");


### PR DESCRIPTION
Implements #15

Closes #15

## Summary
- expose substep target dt and max substeps through config and CLI
- publish effective substep stats through server status, CLI, and Qt UI
- add runtime and protocol regression coverage for configured substep policy

## Validation
- ctest --test-dir build-quality --output-on-failure --no-tests=error -R "ConfigArgsTest\.TST_UNT_CONF_00(3|10)_|ServerProtocolCodecTest\.TST_UNT_PROT_002_"
- ctest --test-dir build-root-issue15 --output-on-failure --no-tests=error -R "PhysicsTest\.TST_UNT_RUNT_004_"
- make quality-local CONFIG=simulation.ini
- make quality-strict CONFIG=simulation.ini QUALITY_BUILD_DIR=build-quality
