### PR TITLE
Issue #31: Deterministic mode with fixed seed and replay test

### DIFF
--- a/cmake/apps.cmake
+++ b/cmake/apps.cmake
@@ -147,7 +147,6 @@ if(GRAVITY_BUILD_CLIENT_MODULES)
     endif()
     gravity_add_client_module_manifest(${CLIENT_MODULE_GUI_PROXY_NAME} gui)
 
-if(GRAVITY_BUILD_CLIENT_MODULES)
     find_package(Qt6 QUIET COMPONENTS Widgets)
     if(NOT Qt6_FOUND AND WIN32)
         if(DEFINED ENV{QT_DIR})

--- a/docs/quality/manifest/test_groups_core.json
+++ b/docs/quality/manifest/test_groups_core.json
@@ -422,6 +422,14 @@
                                                                                                   ]
                                                                                   }
                                                          },
+                        "EVD_TEST_UNIT_PHYSICS_DETERMINISM":  {
+                                                                   "TST-UNT-PHYS-013":  {
+                                                                                            "id":  "PhysicsTest.TST_UNT_PHYS_010_DeterministicReplayIdentical",
+                                                                                            "req_ids":  [
+                                                                                                            "REQ-PHYS-001"
+                                                                                                        ]
+                                                                                        }
+                                                               },
                         "EVD_TEST_INT_UI_QT_WINDOW":  {
                                                           "TST-UIX-UI-001":  {
                                                                                  "id":  "QtMainWindowTest.TST_UIX_UI_001_ConstructsAndTicksWithRealRuntime",

--- a/engine/include/config/SimulationConfig.hpp
+++ b/engine/include/config/SimulationConfig.hpp
@@ -62,6 +62,7 @@ struct SimulationConfig {
     float sphViscosity = 0.08f;
     std::uint32_t energyMeasureEverySteps = 120u;
     std::uint32_t energySampleLimit = 256u;
+    bool deterministicMode = false;
 
     static SimulationConfig defaults();
     static SimulationConfig loadOrCreate(const std::string &path);

--- a/engine/src/config/SimulationConfigDirective.cpp
+++ b/engine/src/config/SimulationConfigDirective.cpp
@@ -167,6 +167,7 @@ static bool applyDirectiveArgs(
             const std::string iniKey =
                 arg.first == "seed" ? "init_seed" :
                 arg.first == "include_central_body" ? "init_include_central_body" :
+                arg.first == "deterministic" ? "deterministic_mode" :
                 arg.first;
             handled = applyIniAlias(arg, iniKey, config, warnings);
         } else if (directive == "central_body") {

--- a/engine/src/config/SimulationConfigDirectiveWrite.cpp
+++ b/engine/src/config/SimulationConfigDirectiveWrite.cpp
@@ -93,7 +93,8 @@ void SimulationConfigDirective::write(std::ostream &out, const SimulationConfig 
         << ", heating=" << config.thermalHeatingCoeff
         << ", radiation=" << config.thermalRadiationCoeff << ")\n";
     out << "generation(seed=" << config.initSeed
-        << ", include_central_body=" << (config.initIncludeCentralBody ? "true" : "false") << ")\n";
+        << ", include_central_body=" << (config.initIncludeCentralBody ? "true" : "false")
+        << ", deterministic=" << (config.deterministicMode ? "true" : "false") << ")\n";
     out << "central_body(mass=" << config.initCentralMass
         << ", x=" << config.initCentralX
         << ", y=" << config.initCentralY

--- a/engine/src/config/SimulationOptionRegistryEntries.cpp
+++ b/engine/src/config/SimulationOptionRegistryEntries.cpp
@@ -61,6 +61,7 @@ const SimulationOptionEntry kSimulationOptions[] = {
     {SimulationOptionGroup::Fluid, OptionKind::Float, "--sph-viscosity", "", "sph_viscosity", "", "", "  --sph-viscosity <float>\n", "", offsetof(SimulationConfig, sphViscosity), 0.0, 0.0, true, false},
     {SimulationOptionGroup::Fluid, OptionKind::Uint, "--energy-every", "", "energy_measure_every_steps", "", "", "  --energy-every <n>\n", "", offsetof(SimulationConfig, energyMeasureEverySteps), 1.0, 0.0, true, false},
     {SimulationOptionGroup::Fluid, OptionKind::Uint, "--energy-sample-limit", "", "energy_sample_limit", "", "", "  --energy-sample-limit <n>\n", "", offsetof(SimulationConfig, energySampleLimit), 64.0, 0.0, true, false},
+    {SimulationOptionGroup::Core, OptionKind::Bool, "--deterministic", "", "deterministic_mode", "", "", "  --deterministic <true|false>\n", "", offsetof(SimulationConfig, deterministicMode), 0.0, 0.0, false, false},
 };
 
 const std::size_t kSimulationOptionCount = sizeof(kSimulationOptions) / sizeof(kSimulationOptions[0]);

--- a/tests/unit/physics/solver.cpp
+++ b/tests/unit/physics/solver.cpp
@@ -176,5 +176,55 @@ TEST(PhysicsTest, TST_UNT_RUNT_002_ParticleSystemCtorKeepsExplicitInitialState)
     EXPECT_FLOAT_EQ(configuredParticles[1].getTemperature(), 2.0f);
 }
 
+TEST(PhysicsTest, TST_UNT_PHYS_010_DeterministicReplayIdentical)
+{
+    ScenarioConfig cfg;
+    cfg.particleCount = 64u;
+    cfg.dt = 0.005f;
+    cfg.steps = 20;
+    cfg.solver = "pairwise_cuda";
+    cfg.integrator = "euler";
+    cfg.energyMeasureEverySteps = 1u;
+    cfg.energySampleLimit = 64u;
+    cfg.snapshotTimeoutMs = 6000;
+    cfg.stepTimeoutMs = 6000;
+    cfg.initState.mode = "disk_orbit";
+    cfg.initState.seed = 77777u;
+    cfg.initState.includeCentralBody = true;
+    cfg.initState.centralMass = 1.0f;
+    cfg.initState.diskMass = 0.5f;
+    cfg.initState.diskRadiusMin = 1.5f;
+    cfg.initState.diskRadiusMax = 8.0f;
+    cfg.initState.diskThickness = 0.0f;
+    cfg.initState.velocityScale = 1.0f;
+    cfg.initState.velocityTemperature = 0.0f;
+    cfg.initState.particleTemperature = 0.0f;
+
+    ScenarioResult runA;
+    std::string errorA;
+    ASSERT_TRUE(runScenario(cfg, runA, errorA)) << errorA;
+    if (runA.stats.solverName != cfg.solver) {
+        GTEST_SKIP() << "solver unavailable (actual="
+                     << runA.stats.solverName << ")";
+    }
+
+    ScenarioResult runB;
+    std::string errorB;
+    ASSERT_TRUE(runScenario(cfg, runB, errorB)) << errorB;
+
+    ASSERT_EQ(runA.final.size(), runB.final.size());
+    for (std::size_t i = 0; i < runA.final.size(); ++i) {
+        EXPECT_FLOAT_EQ(runA.final[i].x, runB.final[i].x)
+            << "mismatch at particle " << i << " .x";
+        EXPECT_FLOAT_EQ(runA.final[i].y, runB.final[i].y)
+            << "mismatch at particle " << i << " .y";
+        EXPECT_FLOAT_EQ(runA.final[i].z, runB.final[i].z)
+            << "mismatch at particle " << i << " .z";
+    }
+
+    EXPECT_FLOAT_EQ(runA.stats.totalEnergy, runB.stats.totalEnergy);
+    EXPECT_EQ(runA.stats.steps, runB.stats.steps);
+}
+
 } // namespace testsupport
 


### PR DESCRIPTION
Implements #31

Closes #31

## Changes
- Add deterministicMode config flag to SimulationConfig
- Register --deterministic CLI option
- Config directive write/parse roundtrip for deterministic flag
- Add deterministic replay test (TST_UNT_PHYS_010_DeterministicReplayIdentical)
- Register test in quality manifest (TST-UNT-PHYS-013)
- Fix CMake apps.cmake nesting bug (duplicate if block)