### PR TITLE
Issue #237: Fix GPU Runner Health CI Failure

### DIFF
--- a/scripts/ci/gpu/bootstrap_windows_runner.py
+++ b/scripts/ci/gpu/bootstrap_windows_runner.py
@@ -2,7 +2,12 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from python_tools.ci.gpu_runner_bootstrap import WindowsGpuRunnerBootstrap
 

--- a/scripts/ci/gpu/runner_health.py
+++ b/scripts/ci/gpu/runner_health.py
@@ -2,7 +2,12 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from python_tools.ci.gpu_runner_inventory import GitHubGpuRunnerInventory
 


### PR DESCRIPTION
Implements #237

Closes #237

Adds sys.path boilerplate to scripts/ci/gpu/runner_health.py and scripts/ci/gpu/bootstrap_windows_runner.py to ensure python_tools package is findable when running from repository root. This resolves the ModuleNotFoundError in the 
ightly-full workflow.