### PR TITLE
Issue #239: Fix GPU Runner Health CI Failure (missing directory)

### DIFF
--- a/python_tools/ci/gpu_runner_inventory.py
+++ b/python_tools/ci/gpu_runner_inventory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import urllib.error
 import urllib.request
+from pathlib import Path
 from collections.abc import Callable, Iterable
 from typing import Protocol
 
@@ -96,6 +97,7 @@ class GitHubGpuRunnerInventory:
         )
 
     def write(self, report: dict[str, object], output_path: str) -> None:
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
         with open(output_path, "w", encoding="utf-8") as handle:
             json.dump(report, handle, indent=2)
 


### PR DESCRIPTION
Implements #239

Closes #239

Updates GitHubGpuRunnerInventory.write to ensure the parent directory of the output file exists before writing. This resolves the FileNotFoundError in the GPU Runner Health job.