### PR TITLE
Issue #241: CI: Ruff import sorting failure in gpu_runner_inventory.py

### DIFF
--- a/python_tools/ci/gpu_runner_inventory.py
+++ b/python_tools/ci/gpu_runner_inventory.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import json
 import urllib.error
 import urllib.request
-from pathlib import Path
 from collections.abc import Callable, Iterable
+from pathlib import Path
 from typing import Protocol
 
 


### PR DESCRIPTION
Implements #241

Closes #241

Fixes the I001 rule violation caused by an un-sorted import block in \gpu_runner_inventory.py\ after manually adding \pathlib.Path\.