### PR TITLE
Issue #17: add Qt backend state indicators

### DIFF
--- a/docs/quality/manifest/requirements.json
+++ b/docs/quality/manifest/requirements.json
@@ -265,7 +265,7 @@
                                                            ],
                                              "tests":  [
                                                            "^QtMainWindowTest\\.TST_UIX_UI_00[1-6]_",
-                                                           "^QtUiLogicTest\\.TST_UNT_UI_00[1-4]_"
+                                                           "^QtUiLogicTest\\.TST_UNT_UI_00[1-5]_"
                                                          ]
                                            },
                           "REQ-TEST-001":  {

--- a/docs/quality/manifest/test_groups_core.json
+++ b/docs/quality/manifest/test_groups_core.json
@@ -634,6 +634,12 @@
                 "req_ids": [
                     "REQ-UI-001"
                 ]
+            },
+            "TST-UNT-UI-005": {
+                "id": "QtUiLogicTest.TST_UNT_UI_005_PresenterHighlightsStaleBackendAndKnownHorizonEta",
+                "req_ids": [
+                    "REQ-UI-001"
+                ]
             }
         },
         "EVD_CHECK_INI": {

--- a/modules/qt/include/ui/MainWindowPresenter.hpp
+++ b/modules/qt/include/ui/MainWindowPresenter.hpp
@@ -29,6 +29,7 @@ struct MainWindowPresentationInput final {
     std::uint32_t snapshotAgeMs = 0u;
     std::uint32_t snapshotLatencyMs = 0u;
     float uiTickFps = 0.0f;
+    float simulationHorizonSeconds = 0.0f;
 };
 
 /// Holds the formatted strings consumed by status and trace widgets.

--- a/modules/qt/ui/MainWindowPresenter.cpp
+++ b/modules/qt/ui/MainWindowPresenter.cpp
@@ -2,8 +2,10 @@
 
 #include "types/SimulationTypes.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <iomanip>
 #include <limits>
 #include <sstream>
 
@@ -31,29 +33,105 @@ class MainWindowPresenterLocal final {
             }
             return "n/a";
         }
+
+        static bool isStale(std::uint32_t ageMs)
+        {
+            return hasAge(ageMs) && ageMs > 1000u;
+        }
+
+        static std::string fixedLabel(float value, int precision)
+        {
+            std::ostringstream stream;
+            stream << std::fixed << std::setprecision(precision) << value;
+            return stream.str();
+        }
+
+        static float simulatedSecondsPerSecond(const MainWindowPresentationInput &input)
+        {
+            float simulatedStep = std::max(0.0f, input.stats.dt);
+            if (input.stats.substeps > 0u && input.stats.substepDt > 0.0f) {
+                simulatedStep = input.stats.substepDt * static_cast<float>(input.stats.substeps);
+            }
+            return std::max(0.0f, simulatedStep * std::max(0.0f, input.stats.serverFps));
+        }
+
+        static std::string backendStateLabel(const MainWindowPresentationInput &input, bool staleStats, bool staleSnapshot)
+        {
+            if (input.stats.faulted) {
+                return "faulted";
+            }
+            if (input.linkLabel != "connected") {
+                return input.linkLabel;
+            }
+            if (input.stats.paused) {
+                return "idle";
+            }
+            if (staleStats && staleSnapshot) {
+                return "stalled";
+            }
+            if (input.stats.serverFps > 0.01f) {
+                return "busy";
+            }
+            return "idle";
+        }
+
+        static std::string viewportStateLabel(std::uint32_t snapshotAgeMs)
+        {
+            if (!hasAge(snapshotAgeMs)) {
+                return "awaiting snapshot";
+            }
+            const std::string age = ageLabel(snapshotAgeMs);
+            return isStale(snapshotAgeMs) ? "stale (" + age + " old)" : "fresh (" + age + " old)";
+        }
+
+        static std::string progressLabel(const MainWindowPresentationInput &input)
+        {
+            if (input.simulationHorizonSeconds <= 0.0f) {
+                return "open-ended";
+            }
+            const float clampedTime = std::clamp(input.stats.totalTime, 0.0f, input.simulationHorizonSeconds);
+            const float pct = (clampedTime / input.simulationHorizonSeconds) * 100.0f;
+            return fixedLabel(pct, 1) + "% (" + fixedLabel(clampedTime, 2) + " / "
+                + fixedLabel(input.simulationHorizonSeconds, 2) + " s)";
+        }
+
+        static std::string etaLabel(const MainWindowPresentationInput &input)
+        {
+            if (input.simulationHorizonSeconds <= 0.0f || input.stats.totalTime >= input.simulationHorizonSeconds) {
+                return input.simulationHorizonSeconds > 0.0f ? "0.0s" : "n/a";
+            }
+            const float simRate = simulatedSecondsPerSecond(input);
+            if (simRate <= 1e-6f || input.stats.paused || input.stats.faulted || input.linkLabel != "connected") {
+                return "n/a";
+            }
+            return fixedLabel((input.simulationHorizonSeconds - input.stats.totalTime) / simRate, 1) + "s";
+        }
 };
 
 MainWindowPresentation MainWindowPresenter::present(const MainWindowPresentationInput &input) const
 {
-    const bool staleStats = MainWindowPresenterLocal::hasAge(input.statsAgeMs) && input.statsAgeMs > 1000u;
-    const bool staleSnapshot = MainWindowPresenterLocal::hasAge(input.snapshotAgeMs) && input.snapshotAgeMs > 1000u;
-    const bool stale = input.linkLabel != "connected" || staleStats || staleSnapshot;
+    const bool staleStats = MainWindowPresenterLocal::isStale(input.statsAgeMs);
+    const bool staleSnapshot = MainWindowPresenterLocal::isStale(input.snapshotAgeMs);
     const std::string faultSuffix = input.stats.faulted
         ? (" [fault@" + std::to_string(input.stats.faultStep) + " " + input.stats.faultReason + "]")
         : (input.stats.energyEstimated ? " (estimated)" : std::string());
     const std::string latency = MainWindowPresenterLocal::latencyLabel(input);
+    const std::string backendState = MainWindowPresenterLocal::backendStateLabel(input, staleStats, staleSnapshot);
+    const std::string viewportState = MainWindowPresenterLocal::viewportStateLabel(input.snapshotAgeMs);
+    const float simRate = MainWindowPresenterLocal::simulatedSecondsPerSecond(input);
+    const std::string progress = MainWindowPresenterLocal::progressLabel(input);
+    const std::string eta = MainWindowPresenterLocal::etaLabel(input);
 
     MainWindowPresentation output;
     std::ostringstream headline;
     headline << "State: " << (input.stats.faulted ? "FAULT" : (input.stats.paused ? "PAUSED" : "RUNNING"))
+             << "\nBackend: " << backendState
+             << "\nViewport: " << viewportState
              << "\nLink: " << input.linkLabel
              << "\nOwner: " << input.ownerLabel
              << "\nEngine: " << input.stats.solverName << " / " << input.stats.integratorName
              << "\nProfile: " << input.performanceProfile
              << "\nSPH: " << (input.stats.sphEnabled ? "on" : "off");
-    if (stale) {
-        headline << "\nData freshness: stale";
-    }
     if (!faultSuffix.empty()) {
         headline << "\nCondition: " << faultSuffix.substr(1);
     }
@@ -65,11 +143,15 @@ MainWindowPresentation MainWindowPresenter::present(const MainWindowPresentation
             << "\nTarget step: " << input.stats.substepTargetDt << " s"
             << "\nSubstep limit: " << input.stats.maxSubsteps
             << "\nServer rate: " << input.stats.serverFps << " step/s"
+            << "\nSim rate: " << MainWindowPresenterLocal::fixedLabel(simRate, 2) << " sim s/s"
+            << "\nPublish cadence: " << input.stats.snapshotPublishPeriodMs << " ms"
             << "\nUI rate: " << input.uiTickFps << " fps";
     output.runtimeText = runtime.str();
 
     std::ostringstream queue;
-    queue << "Steps: " << input.stats.steps
+    queue << "Progress: " << progress
+          << "\nETA: " << eta
+          << "\nSteps: " << input.stats.steps
           << "\nParticles: " << input.stats.particleCount
           << "\nDraw budget: " << input.displayedParticles << " / " << input.clientDrawCap
           << "\nStats age: " << MainWindowPresenterLocal::ageLabel(input.statsAgeMs)
@@ -104,6 +186,11 @@ MainWindowPresentation MainWindowPresenter::present(const MainWindowPresentation
           << " substep_target_dt=" << input.stats.substepTargetDt
           << " max_substeps=" << input.stats.maxSubsteps
           << " snapshot_publish_ms=" << input.stats.snapshotPublishPeriodMs
+          << " backend_state=" << backendState
+          << " viewport_state=\"" << viewportState << "\""
+          << " sim_rate=" << MainWindowPresenterLocal::fixedLabel(simRate, 2)
+          << " progress=\"" << progress << "\""
+          << " eta=\"" << eta << "\""
           << " ui_fps=" << input.uiTickFps
           << " draw=" << input.displayedParticles
           << " draw_cap=" << input.clientDrawCap
@@ -114,7 +201,7 @@ MainWindowPresentation MainWindowPresenter::present(const MainWindowPresentation
           << " dropped_frames=" << input.snapshotPipeline.droppedFrames
           << " snapshot_latency_ms=" << latency
           << " drop_policy=" << input.snapshotPipeline.dropPolicy
-          << " stale=" << (stale ? "1" : "0")
+          << " stale=" << ((input.linkLabel != "connected" || staleStats || staleSnapshot) ? "1" : "0")
           << " faulted=" << (input.stats.faulted ? "1" : "0")
           << " fault_step=" << input.stats.faultStep
           << " fault_reason=\"" << input.stats.faultReason << "\""

--- a/tests/unit/ui/qt_mainwindow_presenter.cpp
+++ b/tests/unit/ui/qt_mainwindow_presenter.cpp
@@ -10,6 +10,7 @@ namespace grav_test_qt_ui {
 TEST(QtUiLogicTest, TST_UNT_UI_001_PresenterFormatsStatusAndTraceFromRuntimeState)
 {
     grav_qt::MainWindowPresentationInput input;
+    input.stats = {};
     input.linkLabel = "connected";
     input.ownerLabel = "external";
     input.performanceProfile = "interactive";
@@ -23,6 +24,9 @@ TEST(QtUiLogicTest, TST_UNT_UI_001_PresenterFormatsStatusAndTraceFromRuntimeStat
     input.snapshotPipeline.queueCapacity = 4u;
     input.snapshotPipeline.droppedFrames = 3u;
     input.snapshotPipeline.dropPolicy = "latest-only";
+    input.stats.paused = false;
+    input.stats.faulted = false;
+    input.stats.faultStep = 0u;
     input.stats.solverName = "pairwise_cuda";
     input.stats.integratorName = "euler";
     input.stats.performanceProfile = "interactive";
@@ -42,19 +46,76 @@ TEST(QtUiLogicTest, TST_UNT_UI_001_PresenterFormatsStatusAndTraceFromRuntimeStat
     input.stats.radiatedEnergy = 0.5f;
     input.stats.totalEnergy = -0.5f;
     input.stats.energyDriftPct = 0.25f;
+    input.stats.energyEstimated = false;
 
     const grav_qt::MainWindowPresentation presentation = grav_qt::MainWindowPresenter().present(input);
 
+    EXPECT_NE(presentation.headlineText.find("Backend: busy"), std::string::npos) << presentation.headlineText;
+    EXPECT_NE(presentation.headlineText.find("Viewport: fresh (18ms old)"), std::string::npos);
     EXPECT_NE(presentation.headlineText.find("Link: connected"), std::string::npos);
     EXPECT_NE(presentation.headlineText.find("Owner: external"), std::string::npos);
+    EXPECT_NE(presentation.runtimeText.find("Sim rate: 1.20 sim s/s"), std::string::npos);
     EXPECT_NE(presentation.runtimeText.find("Substeps: 2 x 0.005"), std::string::npos);
+    EXPECT_NE(presentation.queueText.find("Progress: open-ended"), std::string::npos);
+    EXPECT_NE(presentation.queueText.find("ETA: n/a"), std::string::npos);
     EXPECT_NE(presentation.queueText.find("Queue: 2 / 4"), std::string::npos);
     EXPECT_NE(presentation.queueText.find("Policy: latest-only"), std::string::npos);
     EXPECT_NE(presentation.queueText.find("Latency: 7ms"), std::string::npos);
     EXPECT_NE(presentation.energyText.find("Total: -0.5"), std::string::npos);
     EXPECT_NE(presentation.statusText.find('\n'), std::string::npos);
+    EXPECT_NE(presentation.consoleTrace.find("backend_state=busy"), std::string::npos) << presentation.consoleTrace;
+    EXPECT_NE(presentation.consoleTrace.find("progress=\"open-ended\""), std::string::npos);
     EXPECT_NE(presentation.consoleTrace.find("queue_depth=2"), std::string::npos);
     EXPECT_NE(presentation.consoleTrace.find("drop_policy=latest-only"), std::string::npos);
+}
+
+TEST(QtUiLogicTest, TST_UNT_UI_005_PresenterHighlightsStaleBackendAndKnownHorizonEta)
+{
+    grav_qt::MainWindowPresentationInput input;
+    input.stats = {};
+    input.linkLabel = "connected";
+    input.ownerLabel = "embedded";
+    input.performanceProfile = "quality";
+    input.statsAgeMs = 2100u;
+    input.snapshotAgeMs = 2600u;
+    input.snapshotLatencyMs = std::numeric_limits<std::uint32_t>::max();
+    input.simulationHorizonSeconds = 10.0f;
+    input.snapshotPipeline.latencyMs = 45u;
+    input.snapshotPipeline.dropPolicy = "latest-only";
+    input.stats.paused = false;
+    input.stats.faulted = false;
+    input.stats.faultStep = 0u;
+    input.stats.sphEnabled = false;
+    input.stats.serverFps = 80.0f;
+    input.stats.dt = 0.02f;
+    input.stats.totalTime = 4.0f;
+    input.stats.substeps = 0u;
+    input.stats.substepDt = 0.0f;
+    input.stats.substepTargetDt = 0.0f;
+    input.stats.maxSubsteps = 0u;
+    input.stats.snapshotPublishPeriodMs = 0u;
+    input.stats.steps = 200u;
+    input.stats.particleCount = 16384u;
+    input.stats.solverName = "octree_gpu";
+    input.stats.integratorName = "rk4";
+    input.stats.kineticEnergy = 0.0f;
+    input.stats.potentialEnergy = 0.0f;
+    input.stats.thermalEnergy = 0.0f;
+    input.stats.radiatedEnergy = 0.0f;
+    input.stats.totalEnergy = 0.0f;
+    input.stats.energyDriftPct = 0.0f;
+    input.stats.energyEstimated = false;
+
+    const grav_qt::MainWindowPresentation presentation = grav_qt::MainWindowPresenter().present(input);
+
+    EXPECT_NE(presentation.headlineText.find("Backend: stalled"), std::string::npos) << presentation.headlineText;
+    EXPECT_NE(presentation.headlineText.find("Viewport: stale (2600ms old)"), std::string::npos);
+    EXPECT_NE(presentation.queueText.find("Progress: 40.0% (4.00 / 10.00 s)"), std::string::npos);
+    EXPECT_NE(presentation.queueText.find("ETA: "), std::string::npos) << presentation.queueText;
+    EXPECT_EQ(presentation.queueText.find("ETA: n/a"), std::string::npos) << presentation.queueText;
+    EXPECT_NE(presentation.consoleTrace.find("backend_state=stalled"), std::string::npos) << presentation.consoleTrace;
+    EXPECT_NE(presentation.consoleTrace.find("eta=\""), std::string::npos) << presentation.consoleTrace;
+    EXPECT_EQ(presentation.consoleTrace.find("eta=\"n/a\""), std::string::npos) << presentation.consoleTrace;
 }
 
 } // namespace grav_test_qt_ui


### PR DESCRIPTION
Implements #17

Adds explicit Qt backend state, viewport freshness, simulated progress, and ETA cues in the workspace presenter so users can distinguish backend progress from stale rendering.

Requirements impacted:
- REQ-UI-001
- REQ-RUN-001

Validation:
- make quality-local CONFIG=simulation.ini BUILD_DIR=build-issue17
- .\\build-issue17\\tests\\gravityQtUiLogicGTests.exe
- python tests/checks/run.py clang_tidy --root . --build-dir build-quality-issue17 --jobs 8 --path modules/qt/ui/MainWindowPresenter.cpp --path tests/unit/ui/qt_mainwindow_presenter.cpp

Closes #17