### PR TITLE
Issue #20: add Qt GUI smoke progression checks

### DIFF
--- a/docs/quality/manifest/test_groups_core.json
+++ b/docs/quality/manifest/test_groups_core.json
@@ -608,6 +608,13 @@
                 "req_ids": [
                     "REQ-UI-001"
                 ]
+            },
+            "TST-UIX-UI-014": {
+                "id": "QtMainWindowTest.TST_UIX_UI_014_RealRuntimeProgressesAndSurfacesFreshOrStaleViewportState",
+                "req_ids": [
+                    "REQ-UI-001",
+                    "REQ-RUN-001"
+                ]
             }
         },
         "EVD_TEST_UNIT_UI_QT_LOGIC": {

--- a/tests/int/ui/qt_window.cpp
+++ b/tests/int/ui/qt_window.cpp
@@ -3,6 +3,7 @@
 #include "tests/support/client_utils.hpp"
 #include "tests/support/qt_test_utils.hpp"
 #include "tests/support/server_harness.hpp"
+#include "ui/EnergyGraphWidget.hpp"
 #include "ui/MainWindow.hpp"
 
 #include <gtest/gtest.h>
@@ -133,6 +134,64 @@ TEST(QtMainWindowTest, TST_UIX_UI_004_ShowsEffectiveClientCapWhenConfiguredCapEx
             && status.contains("Policy: latest-only");
     }, std::chrono::milliseconds(5000)));
     server.stop();
+}
+
+TEST(QtMainWindowTest, TST_UIX_UI_014_RealRuntimeProgressesAndSurfacesFreshOrStaleViewportState)
+{
+    (void)testsupport::ensureQtApp();
+    RealServerHarness server;
+    std::string startError;
+    ASSERT_TRUE(server.start(startError)) << startError;
+
+    auto runtime = std::make_unique<grav_client::ClientRuntime>(
+        "simulation.ini",
+        testsupport::makeTransport(server.port(), server.executablePath()));
+    grav_qt::MainWindow window(makeUiConfig(), "simulation.ini", std::move(runtime));
+    window.show();
+
+    ASSERT_TRUE(testsupport::waitUntilUi([&]() {
+        return testsupport::findStatusLabelText(window).contains("Link: connected");
+    }, std::chrono::milliseconds(5000)));
+
+    QWidget *graphWidget = window.findChild<QWidget *>("energyGraphWidget");
+    auto *graph = dynamic_cast<grav_qt::EnergyGraphWidget *>(graphWidget);
+    ASSERT_NE(graph, nullptr);
+
+    const std::uint64_t initialSteps = testsupport::findSummaryUnsignedMetric(window, "Steps: ");
+    const std::size_t initialSamples = graph->sampleCount();
+    QPushButton *pauseButton = window.findChild<QPushButton *>("pauseToggleButton");
+    ASSERT_NE(pauseButton, nullptr);
+    if (pauseButton->text() == "Resume" || testsupport::findStatusLabelText(window).contains("State: PAUSED")) {
+        pauseButton->click();
+    }
+
+    const bool progressed = testsupport::waitUntilUi([&]() {
+        const QString status = testsupport::findStatusLabelText(window);
+        return status.contains("Link: connected")
+            && status.contains("State: RUNNING")
+            && status.contains("Backend: busy")
+            && status.contains("Viewport: fresh")
+            && !status.contains("Backend: stalled")
+            && testsupport::findSummaryUnsignedMetric(window, "Steps: ") > initialSteps
+            && graph->sampleCount() > initialSamples;
+    }, std::chrono::milliseconds(7000));
+    if (!progressed) {
+        const std::filesystem::path evidence = testsupport::saveFailureEvidence(window, "gravity_qt_progression_failure");
+        ADD_FAILURE() << "runtime did not show real progression; evidence at " << evidence.string();
+    }
+    ASSERT_TRUE(progressed);
+
+    server.stop();
+    const bool staleAfterStop = testsupport::waitUntilUi([&]() {
+        const QString status = testsupport::findStatusLabelText(window);
+        return status.contains("Link: reconnecting")
+            && (status.contains("Viewport: stale") || status.contains("Viewport: awaiting snapshot"));
+    }, std::chrono::milliseconds(7000));
+    if (!staleAfterStop) {
+        const std::filesystem::path evidence = testsupport::saveFailureEvidence(window, "gravity_qt_stale_failure");
+        ADD_FAILURE() << "viewport did not surface stale/reconnecting state; evidence at " << evidence.string();
+    }
+    EXPECT_TRUE(staleAfterStop);
 }
 
 } // namespace grav_test_qt_window

--- a/tests/support/qt_test_utils.cpp
+++ b/tests/support/qt_test_utils.cpp
@@ -59,6 +59,31 @@ QString findStatusLabelText(const grav_qt::MainWindow &window)
     return summaryLines.join("\n");
 }
 
+std::filesystem::path saveFailureEvidence(grav_qt::MainWindow &window, const std::string &stem)
+{
+    const std::filesystem::path basePath = std::filesystem::temp_directory_path() / stem;
+    (void)window.grab().save(QString::fromStdString(basePath.string() + ".png"));
+    std::ofstream out(basePath.string() + ".txt", std::ios::binary);
+    out << findStatusLabelText(window).toStdString();
+    return basePath;
+}
+
+std::uint64_t findSummaryUnsignedMetric(const grav_qt::MainWindow &window, const std::string &label)
+{
+    const std::string status = findStatusLabelText(window).toStdString();
+    const std::size_t offset = status.find(label);
+    if (offset == std::string::npos) {
+        return 0u;
+    }
+    std::size_t cursor = offset + label.size();
+    std::uint64_t value = 0u;
+    while (cursor < status.size() && status[cursor] >= '0' && status[cursor] <= '9') {
+        value = (value * 10u) + static_cast<std::uint64_t>(status[cursor] - '0');
+        cursor += 1u;
+    }
+    return value;
+}
+
 std::string readAllFile(const std::filesystem::path &path)
 {
     std::ifstream in(path, std::ios::binary);

--- a/tests/support/qt_test_utils.hpp
+++ b/tests/support/qt_test_utils.hpp
@@ -22,6 +22,10 @@ QApplication *ensureQtApp();
 
 QString findStatusLabelText(const grav_qt::MainWindow &window);
 
+std::filesystem::path saveFailureEvidence(grav_qt::MainWindow &window, const std::string &stem);
+
+std::uint64_t findSummaryUnsignedMetric(const grav_qt::MainWindow &window, const std::string &label);
+
 std::string readAllFile(const std::filesystem::path &path);
 
 QComboBox *findSolverCombo(grav_qt::MainWindow &window);


### PR DESCRIPTION
Implements #20

Adds a real-runtime Qt smoke check that verifies the window does more than stay alive: it must surface real step progression, keep the viewport fresh while the backend is advancing, and transition to a stale/reconnecting state after backend loss. The test captures a screenshot and summary text on failure to make backend stalls distinguishable from a pure UI rendering problem.

Validation:
- make quality-local CONFIG=simulation.ini BUILD_DIR=build-issue20
- cmake --build build-issue20 --target gravityQtMainWindowGTests --config Debug --parallel 1
- cmake --build build-issue20 --target blitzar-server --config Debug --parallel 1
- build-issue20\\tests\\gravityQtMainWindowGTests.exe --gtest_filter=QtMainWindowTest.TST_UIX_UI_001_ConstructsAndTicksWithRealRuntime:QtMainWindowTest.TST_UIX_UI_002_ShowsReconnectingWhenServerStopsAndRecovers:QtMainWindowTest.TST_UIX_UI_004_ShowsEffectiveClientCapWhenConfiguredCapExceedsProtocolMax:QtMainWindowTest.TST_UIX_UI_014_RealRuntimeProgressesAndSurfacesFreshOrStaleViewportState
- python tests/checks/run.py clang_tidy --root . --build-dir build-issue20 --jobs 8 --path tests/int/ui/qt_window.cpp --path tests/support/qt_test_utils.cpp

Closes #20