### PR TITLE
Issue #278: refine file policy thresholds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,12 @@ make quality-strict CONFIG=simulation.ini QUALITY_BUILD_DIR=build-quality
 ## File Size Policy (All Files)
 
 - Apply this policy to every file type (`.cpp`, `.hpp`, `.cu`, `.cmake`, `.md`, scripts, etc.).
+- One file must keep one clear primary responsibility.
 - Target file length: `<= 200` lines.
 - Hard limit: `<= 300` lines.
-- If a file grows past the hard limit, split it by responsibility immediately.
+- Files above the target remain reviewable only if the responsibility is still clear and the implementation stays simple.
+- If a file grows past the hard limit, split it by responsibility immediately instead of creating thin wrapper files just to satisfy the counter.
+- Repository policy warnings may also flag very large functions or multiple substantial functions in the same implementation file as decomposition signals even when the file still fits under the hard limit.
 - Allowed exceptions: generated files, vendored third-party code, or performance-critical fragments; document the reason in the related PR/issue.
 
 ## C++ Conventions

--- a/docs/quality/README.md
+++ b/docs/quality/README.md
@@ -45,7 +45,7 @@ This folder contains the repository-level quality baseline for high-assurance wo
 - The enforceable subset of the `Power of 10` profile is checked in repository policy, including open-ended loop, macro, and function-pointer constraints on production C++ paths; non-automatable rules remain review-gated.
 - Strict analyzer lanes also cover ignored return values via `clang-tidy` and `[[nodiscard]]` on internal status APIs.
 - Quality payload is loaded through deterministic include merge with cycle/duplicate-key protections.
-- All quality artifacts remain constrained by repository file-size policy (target `<=200`, hard `<=300` lines).
+- All quality artifacts remain constrained by repository file-size policy (target `<=200`, hard `<=300` lines) and review-oriented decomposition signals for oversized or clustered implementation functions.
 - Evidence references remain `EVD_*` only (no hardcoded file paths in policy rows).
 - Temporary exceptions must be recorded in `manifest/deviations.json` with owner, approver, rationale, and review date.
 - Release candidates should emit a release-quality index before deep evidence review.

--- a/docs/quality/power_of_10.md
+++ b/docs/quality/power_of_10.md
@@ -36,7 +36,9 @@ The profile is used in two modes:
    Automation status: `partial`
    Automated checks:
    - repository file-size policy remains enforced
+   - repository policy warns on oversized implementation functions and files with multiple substantial functions
    Policy note:
+   - line count is only a proxy; split by responsibility, not by mechanical wrapper extraction
    - function size and decomposition remain review items
 
 5. `Use at least two assertions per function on average`

--- a/docs/quality/quality_manifest.json
+++ b/docs/quality/quality_manifest.json
@@ -2,7 +2,7 @@
   "metadata": {
     "system": "BLITZAR",
     "revision": "2026-03-22",
-    "revision_note": "Added a deterministic performance benchmark campaign, GPU benchmark workflow, and summarized artifact generation for solver, integrator, dt, and particle-count matrices."
+    "revision_note": "Refined repository decomposition policy with responsibility-first file-size guidance and large-function warnings, while preserving deterministic benchmark and GPU evidence coverage."
   },
   "includes": [
     "manifest/evidence.json",

--- a/docs/quality/standards_profile.md
+++ b/docs/quality/standards_profile.md
@@ -78,6 +78,7 @@ Build switch:
 - Interactive performance presets may tune snapshot cadence, client draw cap, energy sampling, and bounded substep policy, but must not silently change solver or integrator mode.
 - Production C++ paths (`apps/`, `engine/`, `runtime/`, `modules/`) must not use unnamed namespaces.
 - Production C++ paths must also satisfy the automated subset of the `Power of 10` profile (`goto`, `setjmp`/`longjmp`, `do-while`, open-ended `while(true)`, non-structural object-like macros, and non-ABI function-pointer typedefs are forbidden).
+- Repository policy keeps file-size thresholds as a decomposition signal (`<=200` target, `<=300` hard limit) and supplements them with warnings for oversized or clustered implementation functions rather than rewarding artificial wrapper splits.
 - Physics stability constants (max acceleration, softening floor, etc.) are exposed through `SimulationConfig` to allow deterministic tuning of solver boundaries without recompilation.
 - Configuration parsing and runtime diagnostics must expose explicit SI units for physical quantities unless a field name explicitly carries another unit such as `_ms` or `fps`.
 - Repository C++ headers must use strict include guards, not `#pragma once`.

--- a/python_tools/policies/repo_policy.py
+++ b/python_tools/policies/repo_policy.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from python_tools.core.base_check import BaseCheck
 from python_tools.core.models import CheckContext, CheckResult
 from python_tools.policies.header_definition_policy import find_header_function_definition_lines
+from python_tools.policies.repo_policy_function_metrics import (
+    IMPLEMENTATION_SCAN_EXTS,
+    collect_function_decomposition_warnings,
+)
 
 FORBIDDEN_CPP_EXTS = {".h", ".hh", ".hxx", ".c", ".cc", ".cxx"}
 LINE_COUNT_EXTS = {
@@ -41,7 +45,6 @@ QT_REFERENCE_NEW_RE = re.compile(
 PREPROCESSOR_CONDITIONAL_RE = re.compile(r"(?m)^\s*#(?:if|ifdef|ifndef|elif|else|endif)\b")
 PRAGMA_ONCE_RE = re.compile(r"(?m)^\s*#pragma\s+once\b")
 DEFINE_RE = re.compile(r"(?m)^\s*#define\s+([A-Z][A-Z0-9_]+)\b(?!\s*\()")
-
 
 def should_skip_dir(dirname: str) -> bool:
     return dirname in IGNORED_DIRS or dirname.startswith(("build-", "cmake-build-", ".pytest-basetemp"))
@@ -108,6 +111,8 @@ class RepoPolicyCheck(BaseCheck):
             if content is None:
                 content = path.read_text(encoding="utf-8", errors="ignore")
             self._check_line_count(rel, content, context, allowlist, used_allowlist, result)
+            if suffix in IMPLEMENTATION_SCAN_EXTS:
+                self._check_function_decomposition(rel, content, result)
 
         for stale in sorted(allowlist - used_allowlist):
             result.add_warning(f"allowlist entry not needed anymore: {stale}")
@@ -195,6 +200,10 @@ class RepoPolicyCheck(BaseCheck):
             return
         if line_count > context.target_lines:
             result.add_warning(f"{rel}: {line_count} lines exceeds target {context.target_lines}")
+
+    def _check_function_decomposition(self, rel: str, content: str, result: CheckResult) -> None:
+        for warning in collect_function_decomposition_warnings(rel, content):
+            result.add_warning(warning)
 
     def _check_evidence_workflow_commands(
         self,

--- a/python_tools/policies/repo_policy_function_metrics.py
+++ b/python_tools/policies/repo_policy_function_metrics.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import re
+
+IMPLEMENTATION_SCAN_EXTS = {".cpp", ".cc", ".cxx", ".cu", ".inl"}
+FUNCTION_TARGET_LINES = 80
+SUBSTANTIAL_FUNCTION_LINES = 40
+MULTI_FUNCTION_TARGET = 3
+
+FUNCTION_START_RE = re.compile(
+    r"[A-Za-z_~][A-Za-z0-9_:<>~*&\s,]*\([^;]*\)\s*(?:const\s*)?"
+    r"(?:noexcept\s*)?(?:->\s*[A-Za-z0-9_:<>*&\s]+)?\s*\{"
+)
+CONTROL_FLOW_PREFIXES = ("if", "for", "while", "switch", "catch")
+NON_FUNCTION_PREFIXES = ("class", "struct", "enum", "union", "namespace", "else", "do", "try")
+
+
+def collect_function_decomposition_warnings(rel: str, content: str) -> list[str]:
+    warnings: list[str] = []
+    functions = _collect_function_metrics(content)
+    substantial = [metric for metric in functions if metric["lines"] >= SUBSTANTIAL_FUNCTION_LINES]
+    oversized = [metric for metric in functions if metric["lines"] > FUNCTION_TARGET_LINES]
+
+    for metric in oversized:
+        warnings.append(
+            f"{rel}:{metric['start_line']}: function spans {metric['lines']} lines; "
+            f"target <= {FUNCTION_TARGET_LINES} lines and split by responsibility, not wrappers"
+        )
+
+    if len(substantial) >= MULTI_FUNCTION_TARGET:
+        lines = ", ".join(str(metric["start_line"]) for metric in substantial[:MULTI_FUNCTION_TARGET])
+        warnings.append(
+            f"{rel}: contains {len(substantial)} substantial functions "
+            f"(>= {SUBSTANTIAL_FUNCTION_LINES} lines at {lines}); review file responsibility before it grows"
+        )
+
+    return warnings
+
+
+def _collect_function_metrics(content: str) -> list[dict[str, int]]:
+    lines = content.splitlines()
+    metrics: list[dict[str, int]] = []
+    index = 0
+    while index < len(lines):
+        signature_start = _find_function_signature_start(lines, index)
+        if signature_start is None:
+            index += 1
+            continue
+        (start_index, open_index) = signature_start
+        end_index = _find_matching_block_end(lines, open_index)
+        if end_index is None:
+            index = open_index + 1
+            continue
+        metrics.append({
+            "start_line": start_index + 1,
+            "lines": end_index - start_index + 1,
+        })
+        index = end_index + 1
+    return metrics
+
+
+def _find_function_signature_start(lines: list[str], index: int) -> tuple[int, int] | None:
+    line = lines[index].strip()
+    if not line or line.startswith("#"):
+        return None
+
+    signature_lines: list[str] = []
+    start_index = index
+    current = index
+    while current < len(lines):
+        stripped = lines[current].strip()
+        if not stripped:
+            if signature_lines:
+                break
+            return None
+        if stripped.startswith("#"):
+            return None
+        signature_lines.append(stripped)
+        candidate = " ".join(signature_lines)
+        if "{" in stripped:
+            if _is_function_signature(candidate):
+                return (start_index, current)
+            return None
+        if ";" in stripped:
+            return None
+        current += 1
+    return None
+
+
+def _is_function_signature(candidate: str) -> bool:
+    normalized = candidate.strip()
+    if not FUNCTION_START_RE.search(normalized):
+        return False
+    prefix = normalized.split("(", maxsplit=1)[0].strip().split()[-1].lower()
+    if prefix in CONTROL_FLOW_PREFIXES:
+        return False
+    if normalized.lower().startswith(NON_FUNCTION_PREFIXES):
+        return False
+    return True
+
+
+def _find_matching_block_end(lines: list[str], start_index: int) -> int | None:
+    depth = 0
+    for index in range(start_index, len(lines)):
+        line = lines[index]
+        depth += line.count("{")
+        depth -= line.count("}")
+        if depth == 0 and "}" in line:
+            return index
+    return None

--- a/tests/checks/suites/policy/test_repo_policy.py
+++ b/tests/checks/suites/policy/test_repo_policy.py
@@ -131,6 +131,57 @@ def test_repo_policy_rejects_json_above_hard_limit(tmp_path: Path) -> None:
     assert any("oversize.json" in error and "exceeds hard limit" in error for error in errors)
 
 
+def test_repo_policy_warns_when_file_exceeds_target_but_not_hard_limit(tmp_path: Path) -> None:
+    content = "line\n" * 205
+    _write(tmp_path / "docs" / "quality" / "target_warning.md", content)
+    ok, errors, warnings = _run(tmp_path, tmp_path / "allowlist.txt")
+    assert ok
+    assert not errors
+    assert any("target_warning.md: 205 lines exceeds target 200" in warning for warning in warnings)
+
+
+def test_repo_policy_warns_on_oversized_implementation_function(tmp_path: Path) -> None:
+    body = "".join(f"    value += {index};\n" for index in range(85))
+    _write(
+        tmp_path / cpp_file(ENGINE_SERVER_DIR, "large_function"),
+        "int largeFunction() {\n"
+        "    int value = 0;\n"
+        f"{body}"
+        "    return value;\n"
+        "}\n",
+    )
+    ok, errors, warnings = _run(tmp_path, tmp_path / "allowlist.txt")
+    assert ok
+    assert not errors
+    assert any("function spans" in warning and "large_function.cpp:1" in warning for warning in warnings)
+
+
+def test_repo_policy_warns_on_multiple_substantial_functions_in_one_file(tmp_path: Path) -> None:
+    function_block = "".join(f"    value += {index};\n" for index in range(38))
+    content = (
+        "int alpha() {\n"
+        "    int value = 0;\n"
+        f"{function_block}"
+        "    return value;\n"
+        "}\n\n"
+        "int beta() {\n"
+        "    int value = 0;\n"
+        f"{function_block}"
+        "    return value;\n"
+        "}\n\n"
+        "int gamma() {\n"
+        "    int value = 0;\n"
+        f"{function_block}"
+        "    return value;\n"
+        "}\n"
+    )
+    _write(tmp_path / cpp_file(ENGINE_SERVER_DIR, "clustered_functions"), content)
+    ok, errors, warnings = _run(tmp_path, tmp_path / "allowlist.txt")
+    assert ok
+    assert not errors
+    assert any("contains 3 substantial functions" in warning for warning in warnings)
+
+
 def test_repo_policy_rejects_evidence_workflow_without_prod_profile(tmp_path: Path) -> None:
     _write(
         tmp_path / ".github" / "workflows" / "release-lane.yml",


### PR DESCRIPTION
Implements #278

## Summary
- refine the repository file-size policy to stay responsibility-first instead of line-count-only
- add lightweight decomposition warnings for oversized implementation functions and clustered substantial functions
- document the updated policy in the NASA-first quality artifacts

## Validation
- python -m pytest -q tests/checks/suites/policy/test_repo_policy.py tests/checks/suites/policy/test_repo_policy_power_of_10.py tests/checks/suites/policy/test_repo_policy_headers.py
- python tests/checks/check.py quality --root .
- make quality-local CONFIG=simulation.ini BUILD_DIR=build-issue22
- make quality-strict CONFIG=simulation.ini QUALITY_BUILD_DIR=build-quality-issue278 QUALITY_TIDY_JOBS=8

Closes #278