### PR TITLE
Issue #280: add decomposition policy thresholds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,10 +104,12 @@ make quality-strict CONFIG=simulation.ini QUALITY_BUILD_DIR=build-quality
 - Apply this policy to every file type (`.cpp`, `.hpp`, `.cu`, `.cmake`, `.md`, scripts, etc.).
 - One file must keep one clear primary responsibility.
 - Target file length: `<= 200` lines.
-- Hard limit: `<= 300` lines.
+- Strong alert threshold: `> 300` lines.
 - Files above the target remain reviewable only if the responsibility is still clear and the implementation stays simple.
-- If a file grows past the hard limit, split it by responsibility immediately instead of creating thin wrapper files just to satisfy the counter.
-- Repository policy warnings may also flag very large functions or multiple substantial functions in the same implementation file as decomposition signals even when the file still fits under the hard limit.
+- Files above `300` lines require an explicit deviation and must stay coherent while the split is prepared.
+- If a file grows past the strong alert threshold, split it by responsibility instead of creating thin wrapper files just to satisfy the counter.
+- Artificial refactors whose only purpose is to game the line counter are forbidden.
+- Repository policy warnings may also flag very large functions, too many implementation functions in one file, and functions with excessive branching complexity as decomposition signals even when the file still fits under the alert threshold.
 - Allowed exceptions: generated files, vendored third-party code, or performance-critical fragments; document the reason in the related PR/issue.
 
 ## C++ Conventions

--- a/docs/quality/README.md
+++ b/docs/quality/README.md
@@ -45,7 +45,7 @@ This folder contains the repository-level quality baseline for high-assurance wo
 - The enforceable subset of the `Power of 10` profile is checked in repository policy, including open-ended loop, macro, and function-pointer constraints on production C++ paths; non-automatable rules remain review-gated.
 - Strict analyzer lanes also cover ignored return values via `clang-tidy` and `[[nodiscard]]` on internal status APIs.
 - Quality payload is loaded through deterministic include merge with cycle/duplicate-key protections.
-- All quality artifacts remain constrained by repository file-size policy (target `<=200`, hard `<=300` lines) and review-oriented decomposition signals for oversized or clustered implementation functions.
+- All quality artifacts remain constrained by repository decomposition policy (target `<=200`, strong alert `>300` lines) and review-oriented signals for oversized functions, excessive function counts, and elevated lightweight branching complexity.
 - Evidence references remain `EVD_*` only (no hardcoded file paths in policy rows).
 - Temporary exceptions must be recorded in `manifest/deviations.json` with owner, approver, rationale, and review date.
 - Release candidates should emit a release-quality index before deep evidence review.

--- a/docs/quality/power_of_10.md
+++ b/docs/quality/power_of_10.md
@@ -36,7 +36,7 @@ The profile is used in two modes:
    Automation status: `partial`
    Automated checks:
    - repository file-size policy remains enforced
-   - repository policy warns on oversized implementation functions and files with multiple substantial functions
+   - repository policy warns on oversized implementation functions, excessive implementation-function counts per file, and elevated lightweight branching complexity
    Policy note:
    - line count is only a proxy; split by responsibility, not by mechanical wrapper extraction
    - function size and decomposition remain review items

--- a/docs/quality/quality_manifest.json
+++ b/docs/quality/quality_manifest.json
@@ -2,7 +2,7 @@
   "metadata": {
     "system": "BLITZAR",
     "revision": "2026-03-22",
-    "revision_note": "Refined repository decomposition policy with responsibility-first file-size guidance and large-function warnings, while preserving deterministic benchmark and GPU evidence coverage."
+    "revision_note": "Refined repository decomposition policy with responsibility-first file thresholds, coherent >300 deviations, and lightweight function-count, size, and complexity warnings."
   },
   "includes": [
     "manifest/evidence.json",

--- a/docs/quality/standards_profile.md
+++ b/docs/quality/standards_profile.md
@@ -78,7 +78,7 @@ Build switch:
 - Interactive performance presets may tune snapshot cadence, client draw cap, energy sampling, and bounded substep policy, but must not silently change solver or integrator mode.
 - Production C++ paths (`apps/`, `engine/`, `runtime/`, `modules/`) must not use unnamed namespaces.
 - Production C++ paths must also satisfy the automated subset of the `Power of 10` profile (`goto`, `setjmp`/`longjmp`, `do-while`, open-ended `while(true)`, non-structural object-like macros, and non-ABI function-pointer typedefs are forbidden).
-- Repository policy keeps file-size thresholds as a decomposition signal (`<=200` target, `<=300` hard limit) and supplements them with warnings for oversized or clustered implementation functions rather than rewarding artificial wrapper splits.
+- Repository policy keeps file-size thresholds as a decomposition signal (`<=200` target, strong alert `>300`) and supplements them with warnings for oversized functions, excessive function counts, and lightweight complexity signals rather than rewarding artificial wrapper splits.
 - Physics stability constants (max acceleration, softening floor, etc.) are exposed through `SimulationConfig` to allow deterministic tuning of solver boundaries without recompilation.
 - Configuration parsing and runtime diagnostics must expose explicit SI units for physical quantities unless a field name explicitly carries another unit such as `_ms` or `fps`.
 - Repository C++ headers must use strict include guards, not `#pragma once`.

--- a/python_tools/policies/repo_policy.py
+++ b/python_tools/policies/repo_policy.py
@@ -192,14 +192,21 @@ class RepoPolicyCheck(BaseCheck):
         if line_count > context.hard_lines:
             if rel in allowlist:
                 used_allowlist.add(rel)
+                result.add_warning(
+                    f"{rel}: strong file-size alert; {line_count} lines exceeds {context.hard_lines} "
+                    "under an explicit deviation, keep the file coherent until it is split"
+                )
             else:
                 result.add_error(
-                    f"{rel}: {line_count} lines exceeds hard limit {context.hard_lines} "
-                    "(split file or document explicit exception)"
+                    f"{rel}: {line_count} lines exceeds strong alert threshold {context.hard_lines} "
+                    "(split file or document a coherent exception in the deviation register)"
                 )
             return
         if line_count > context.target_lines:
-            result.add_warning(f"{rel}: {line_count} lines exceeds target {context.target_lines}")
+            result.add_warning(
+                f"{rel}: {line_count} lines exceeds target {context.target_lines}; "
+                "keep one primary responsibility and avoid artificial wrapper splits"
+            )
 
     def _check_function_decomposition(self, rel: str, content: str, result: CheckResult) -> None:
         for warning in collect_function_decomposition_warnings(rel, content):

--- a/python_tools/policies/repo_policy_function_metrics.py
+++ b/python_tools/policies/repo_policy_function_metrics.py
@@ -4,8 +4,13 @@ import re
 
 IMPLEMENTATION_SCAN_EXTS = {".cpp", ".cc", ".cxx", ".cu", ".inl"}
 FUNCTION_TARGET_LINES = 80
+FUNCTION_ALERT_LINES = 140
 SUBSTANTIAL_FUNCTION_LINES = 40
 MULTI_FUNCTION_TARGET = 3
+FILE_FUNCTION_TARGET = 8
+FILE_FUNCTION_ALERT = 12
+FUNCTION_COMPLEXITY_TARGET = 12
+FUNCTION_COMPLEXITY_ALERT = 20
 
 FUNCTION_START_RE = re.compile(
     r"[A-Za-z_~][A-Za-z0-9_:<>~*&\s,]*\([^;]*\)\s*(?:const\s*)?"
@@ -13,19 +18,33 @@ FUNCTION_START_RE = re.compile(
 )
 CONTROL_FLOW_PREFIXES = ("if", "for", "while", "switch", "catch")
 NON_FUNCTION_PREFIXES = ("class", "struct", "enum", "union", "namespace", "else", "do", "try")
+COMPLEXITY_RE = re.compile(r"\bif\b|\bfor\b|\bwhile\b|\bcase\b|\bcatch\b|&&|\|\||\?")
 
 
 def collect_function_decomposition_warnings(rel: str, content: str) -> list[str]:
     warnings: list[str] = []
     functions = _collect_function_metrics(content)
     substantial = [metric for metric in functions if metric["lines"] >= SUBSTANTIAL_FUNCTION_LINES]
-    oversized = [metric for metric in functions if metric["lines"] > FUNCTION_TARGET_LINES]
-
-    for metric in oversized:
+    if len(functions) > FILE_FUNCTION_TARGET:
+        level = "strong function-count alert" if len(functions) > FILE_FUNCTION_ALERT else "function-count warning"
         warnings.append(
-            f"{rel}:{metric['start_line']}: function spans {metric['lines']} lines; "
-            f"target <= {FUNCTION_TARGET_LINES} lines and split by responsibility, not wrappers"
+            f"{rel}: {level}; {len(functions)} implementation functions exceeds target {FILE_FUNCTION_TARGET} "
+            "for one primary responsibility"
         )
+
+    for metric in functions:
+        if metric["lines"] > FUNCTION_TARGET_LINES:
+            level = "strong function-size alert" if metric["lines"] > FUNCTION_ALERT_LINES else "function-size warning"
+            warnings.append(
+                f"{rel}:{metric['start_line']}: {level}; function spans {metric['lines']} lines "
+                f"(target <= {FUNCTION_TARGET_LINES})"
+            )
+        if metric["complexity"] > FUNCTION_COMPLEXITY_TARGET:
+            level = "strong complexity alert" if metric["complexity"] > FUNCTION_COMPLEXITY_ALERT else "complexity warning"
+            warnings.append(
+                f"{rel}:{metric['start_line']}: {level}; estimated branching complexity {metric['complexity']} "
+                f"exceeds target {FUNCTION_COMPLEXITY_TARGET}"
+            )
 
     if len(substantial) >= MULTI_FUNCTION_TARGET:
         lines = ", ".join(str(metric["start_line"]) for metric in substantial[:MULTI_FUNCTION_TARGET])
@@ -54,6 +73,7 @@ def _collect_function_metrics(content: str) -> list[dict[str, int]]:
         metrics.append({
             "start_line": start_index + 1,
             "lines": end_index - start_index + 1,
+            "complexity": _estimate_branching_complexity(lines[start_index:end_index + 1]),
         })
         index = end_index + 1
     return metrics
@@ -108,3 +128,8 @@ def _find_matching_block_end(lines: list[str], start_index: int) -> int | None:
         if depth == 0 and "}" in line:
             return index
     return None
+
+
+def _estimate_branching_complexity(function_lines: list[str]) -> int:
+    body = "\n".join(function_lines)
+    return 1 + len(COMPLEXITY_RE.findall(body))

--- a/tests/checks/policy_allowlist.txt
+++ b/tests/checks/policy_allowlist.txt
@@ -1,4 +1,4 @@
-# Temporary exceptions for files above the 300-line hard limit.
+# Temporary coherent exceptions for files above the 300-line strong alert threshold.
 # Keep this list short and remove entries as files are split by responsibility.
 # Each active group must also exist in docs/quality/manifest/deviations.json.
 

--- a/tests/checks/suites/policy/test_repo_policy.py
+++ b/tests/checks/suites/policy/test_repo_policy.py
@@ -128,7 +128,7 @@ def test_repo_policy_rejects_json_above_hard_limit(tmp_path: Path) -> None:
     _write(tmp_path / "docs" / "quality" / "oversize.json", oversize)
     ok, errors, _ = _run(tmp_path, tmp_path / "allowlist.txt")
     assert not ok
-    assert any("oversize.json" in error and "exceeds hard limit" in error for error in errors)
+    assert any("oversize.json" in error and "strong alert threshold" in error for error in errors)
 
 
 def test_repo_policy_warns_when_file_exceeds_target_but_not_hard_limit(tmp_path: Path) -> None:
@@ -140,46 +140,6 @@ def test_repo_policy_warns_when_file_exceeds_target_but_not_hard_limit(tmp_path:
     assert any("target_warning.md: 205 lines exceeds target 200" in warning for warning in warnings)
 
 
-def test_repo_policy_warns_on_oversized_implementation_function(tmp_path: Path) -> None:
-    body = "".join(f"    value += {index};\n" for index in range(85))
-    _write(
-        tmp_path / cpp_file(ENGINE_SERVER_DIR, "large_function"),
-        "int largeFunction() {\n"
-        "    int value = 0;\n"
-        f"{body}"
-        "    return value;\n"
-        "}\n",
-    )
-    ok, errors, warnings = _run(tmp_path, tmp_path / "allowlist.txt")
-    assert ok
-    assert not errors
-    assert any("function spans" in warning and "large_function.cpp:1" in warning for warning in warnings)
-
-
-def test_repo_policy_warns_on_multiple_substantial_functions_in_one_file(tmp_path: Path) -> None:
-    function_block = "".join(f"    value += {index};\n" for index in range(38))
-    content = (
-        "int alpha() {\n"
-        "    int value = 0;\n"
-        f"{function_block}"
-        "    return value;\n"
-        "}\n\n"
-        "int beta() {\n"
-        "    int value = 0;\n"
-        f"{function_block}"
-        "    return value;\n"
-        "}\n\n"
-        "int gamma() {\n"
-        "    int value = 0;\n"
-        f"{function_block}"
-        "    return value;\n"
-        "}\n"
-    )
-    _write(tmp_path / cpp_file(ENGINE_SERVER_DIR, "clustered_functions"), content)
-    ok, errors, warnings = _run(tmp_path, tmp_path / "allowlist.txt")
-    assert ok
-    assert not errors
-    assert any("contains 3 substantial functions" in warning for warning in warnings)
 
 
 def test_repo_policy_rejects_evidence_workflow_without_prod_profile(tmp_path: Path) -> None:

--- a/tests/checks/suites/policy/test_repo_policy_decomposition.py
+++ b/tests/checks/suites/policy/test_repo_policy_decomposition.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.checks.suites.policy.test_repo_policy import _run, _write
+from tests.checks.suites.support.path_specs import ENGINE_SERVER_DIR, cpp_file
+
+
+def test_repo_policy_warns_when_allowlisted_file_exceeds_strong_alert_threshold(tmp_path: Path) -> None:
+    oversize = "{\n" + "\"k\":0,\n" * 305 + "\"end\":1\n}\n"
+    rel = Path("docs/quality/oversize.json")
+    _write(tmp_path / rel, oversize)
+    allowlist = tmp_path / "allowlist.txt"
+    allowlist.write_text(f"{rel.as_posix()}\n", encoding="utf-8")
+    ok, errors, warnings = _run(tmp_path, allowlist)
+    assert ok
+    assert not errors
+    assert any("strong file-size alert" in warning and rel.as_posix() in warning for warning in warnings)
+
+
+def test_repo_policy_warns_on_oversized_implementation_function(tmp_path: Path) -> None:
+    body = "".join(f"    value += {index};\n" for index in range(85))
+    _write(
+        tmp_path / cpp_file(ENGINE_SERVER_DIR, "large_function"),
+        "int largeFunction() {\n"
+        "    int value = 0;\n"
+        f"{body}"
+        "    return value;\n"
+        "}\n",
+    )
+    ok, errors, warnings = _run(tmp_path, tmp_path / "allowlist.txt")
+    assert ok
+    assert not errors
+    assert any("function-size warning" in warning and "large_function.cpp:1" in warning for warning in warnings)
+
+
+def test_repo_policy_warns_on_multiple_substantial_functions_in_one_file(tmp_path: Path) -> None:
+    function_block = "".join(f"    value += {index};\n" for index in range(38))
+    content = (
+        "int alpha() {\n"
+        "    int value = 0;\n"
+        f"{function_block}"
+        "    return value;\n"
+        "}\n\n"
+        "int beta() {\n"
+        "    int value = 0;\n"
+        f"{function_block}"
+        "    return value;\n"
+        "}\n\n"
+        "int gamma() {\n"
+        "    int value = 0;\n"
+        f"{function_block}"
+        "    return value;\n"
+        "}\n"
+    )
+    _write(tmp_path / cpp_file(ENGINE_SERVER_DIR, "clustered_functions"), content)
+    ok, errors, warnings = _run(tmp_path, tmp_path / "allowlist.txt")
+    assert ok
+    assert not errors
+    assert any("contains 3 substantial functions" in warning for warning in warnings)
+
+
+def test_repo_policy_warns_on_excessive_function_count_in_one_file(tmp_path: Path) -> None:
+    functions = []
+    for index in range(9):
+        functions.append(
+            f"int func{index}() {{\n"
+            "    return 1;\n"
+            "}\n"
+        )
+    _write(tmp_path / cpp_file(ENGINE_SERVER_DIR, "many_functions"), "\n".join(functions))
+    ok, errors, warnings = _run(tmp_path, tmp_path / "allowlist.txt")
+    assert ok
+    assert not errors
+    assert any("function-count warning" in warning and "many_functions.cpp" in warning for warning in warnings)
+
+
+def test_repo_policy_warns_on_elevated_branching_complexity(tmp_path: Path) -> None:
+    conditions = "".join(
+        f"    if (value == {index} && ready) {{\n        total += {index};\n    }}\n"
+        for index in range(7)
+    )
+    _write(
+        tmp_path / cpp_file(ENGINE_SERVER_DIR, "complex_function"),
+        "int complexFunction(int value, bool ready) {\n"
+        "    int total = 0;\n"
+        f"{conditions}"
+        "    return total;\n"
+        "}\n",
+    )
+    ok, errors, warnings = _run(tmp_path, tmp_path / "allowlist.txt")
+    assert ok
+    assert not errors
+    assert any("complexity warning" in warning and "complex_function.cpp:1" in warning for warning in warnings)


### PR DESCRIPTION
Implements #280

## Summary
- update the repository decomposition policy to use a responsibility-first target <=200 and a strong alert >300 with coherent deviations
- add lightweight function-count, function-size, and branching-complexity warnings to the repo policy
- split policy tests by responsibility while keeping the quality artifacts aligned with the new rule wording

## Validation
- python -m pytest -q tests/checks/suites/policy/test_repo_policy.py tests/checks/suites/policy/test_repo_policy_decomposition.py tests/checks/suites/policy/test_repo_policy_power_of_10.py tests/checks/suites/policy/test_repo_policy_headers.py
- python tests/checks/check.py quality --root .
- make quality-local CONFIG=simulation.ini BUILD_DIR=build-issue22
- make quality-strict CONFIG=simulation.ini QUALITY_BUILD_DIR=build-quality-issue280 QUALITY_TIDY_JOBS=8

Closes #280