### PR TITLE
Issue #54: package portable Windows runtime bundle

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -118,6 +118,11 @@ jobs:
         run: |
           python scripts/ci/release/package_bundle.py --build-dir build --dist-dir dist/release-bundle --tool-manifest dist/tool-qualification/tool_manifest.json
 
+      - name: Smoke-validate portable release bundle
+        shell: pwsh
+        run: |
+          python scripts/ci/release/smoke_portable_bundle.py --archive (Get-ChildItem dist/release-bundle/*.zip | Select-Object -First 1).FullName --extract-dir dist/release-bundle-smoke
+
       - name: Package release SBOM
         run: |
           python scripts/ci/release/package_sbom.py --artifacts-dir dist/release-bundle --dist-dir dist/release-sbom

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ make quality-strict
 
 In `PROFILE=prod`, `blitzar-client` and dynamic client modules are disabled by design. In `PROFILE=dev`, client modules load through a manifest-verified, checksum-checked host path.
 
+## Portable Windows Bundle
+
+The release lane packages a zipped Windows runtime bundle in `dist/release-bundle/`. The bundle always includes the built BLITZAR executables plus `simulation.ini`, `README.md`, and `tool_manifest.json` when available. When a Windows build also contains client modules or Qt runtime files, the bundle now preserves the required adjacent `.dll`, `.dll.manifest`, and Qt plugin directories such as `platforms/qwindows.dll`.
+
+The release lane also extracts the generated archive and smoke-validates the portable layout on a clean hosted Windows runner by executing the packaged help commands for each bundled executable.
+
 ## Coverage
 
 - Dashboard: https://luis1454.github.io/BLITZAR/

--- a/docs/README_full.md
+++ b/docs/README_full.md
@@ -156,6 +156,8 @@ build/blitzar-headless.exe --config simulation.ini --particle-count 50000 --targ
 
 On Windows, building `gravityClientModuleQtInProc` now runs `windeployqt` automatically when the tool is available, so `platforms/qwindows.dll` and the required Qt DLLs land in the build directory next to `blitzar-client.exe`.
 
+The release lane packages the resulting Windows runtime layout as a portable ZIP bundle. When Qt/client-module artifacts are present in the build directory, the bundle keeps the adjacent `.dll`, `.dll.manifest`, and plugin directories, then extracts the archive and smoke-runs the packaged executables on the hosted Windows runner.
+
 Manual fallback if needed:
 
 ```bash

--- a/python_tools/ci/release_bundle.py
+++ b/python_tools/ci/release_bundle.py
@@ -2,12 +2,36 @@
 from __future__ import annotations
 
 import shutil
+import subprocess
+import zipfile
+from collections.abc import Callable
 from pathlib import Path
 
 from python_tools.ci.release_support import resolve_release_tag
 
 
 class ReleaseBundlePackager:
+    _EXECUTABLES = (
+        "blitzar.exe",
+        "blitzar-server.exe",
+        "blitzar-headless.exe",
+        "blitzar-client.exe",
+    )
+    _RUNTIME_DIRECTORIES = (
+        "generic",
+        "iconengines",
+        "imageformats",
+        "networkinformation",
+        "platforms",
+        "resources",
+        "styles",
+        "tls",
+    )
+    _ROOT_RUNTIME_FILES = (
+        "qt.conf",
+        "vc_redist.x64.exe",
+    )
+
     def resolve_tag(self, explicit: str | None) -> str:
         return resolve_release_tag(explicit)
 
@@ -17,14 +41,31 @@ class ReleaseBundlePackager:
         dist_dir.mkdir(parents=True, exist_ok=True)
         self._copy_binaries(build_dir, dist_dir)
         self._copy_metadata(dist_dir, tool_manifest)
-        archive_base = dist_dir / f"blitzar-{tag}-windows"
-        return Path(shutil.make_archive(str(archive_base), "zip", root_dir=dist_dir))
+        archive_base = dist_dir.parent / f"blitzar-{tag}-windows"
+        archive_path = Path(shutil.make_archive(str(archive_base), "zip", root_dir=dist_dir))
+        final_archive = dist_dir / archive_path.name
+        if final_archive.exists():
+            final_archive.unlink()
+        shutil.move(str(archive_path), str(final_archive))
+        return final_archive
 
     def _copy_binaries(self, build_dir: Path, dist_dir: Path) -> None:
-        for name in ("blitzar.exe", "blitzar-server.exe", "blitzar-headless.exe", "blitzar-client.exe"):
+        for name in self._EXECUTABLES:
             src = build_dir / name
             if src.exists():
                 shutil.copy2(src, dist_dir / name)
+        for src in sorted(build_dir.glob("*.dll")):
+            shutil.copy2(src, dist_dir / src.name)
+        for src in sorted(build_dir.glob("*.dll.manifest")):
+            shutil.copy2(src, dist_dir / src.name)
+        for name in self._ROOT_RUNTIME_FILES:
+            src = build_dir / name
+            if src.exists():
+                shutil.copy2(src, dist_dir / src.name)
+        for name in self._RUNTIME_DIRECTORIES:
+            src = build_dir / name
+            if src.exists() and src.is_dir():
+                shutil.copytree(src, dist_dir / name, dirs_exist_ok=True)
 
     def _copy_metadata(self, dist_dir: Path, tool_manifest: Path | None) -> None:
         for extra in ("simulation.ini", "README.md"):
@@ -33,3 +74,73 @@ class ReleaseBundlePackager:
                 shutil.copy2(src, dist_dir / src.name)
         if tool_manifest is not None and tool_manifest.exists():
             shutil.copy2(tool_manifest, dist_dir / "tool_manifest.json")
+
+
+class ReleaseBundleSmokeValidator:
+    _HELP_COMMANDS = (
+        ("blitzar.exe", "--help"),
+        ("blitzar-headless.exe", "--help"),
+        ("blitzar-server.exe", "--server-help"),
+        ("blitzar-client.exe", "--help"),
+    )
+
+    def __init__(self, runner: Callable[[list[str], Path], None] | None = None) -> None:
+        self._runner = runner if runner is not None else self._run_command
+
+    def validate_archive(self, archive: Path, extract_dir: Path | None = None, run_commands: bool = True) -> Path:
+        bundle_root = extract_dir if extract_dir is not None else archive.with_suffix("")
+        if bundle_root.exists():
+            shutil.rmtree(bundle_root)
+        bundle_root.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(archive) as bundle:
+            bundle.extractall(bundle_root)
+        self.validate_layout(bundle_root)
+        if run_commands:
+            self.run_smoke(bundle_root)
+        return bundle_root
+
+    def validate_layout(self, bundle_root: Path) -> None:
+        required_files = ("simulation.ini", "README.md")
+        if not any((bundle_root / name).exists() for name, *_ in self._HELP_COMMANDS):
+            raise RuntimeError("portable bundle does not contain any runnable BLITZAR executable")
+        for name in required_files:
+            if not (bundle_root / name).exists():
+                raise RuntimeError(f"portable bundle missing required file: {name}")
+        self._validate_module_manifests(bundle_root)
+        self._validate_qt_runtime(bundle_root)
+
+    def run_smoke(self, bundle_root: Path) -> None:
+        for program, *args in self._HELP_COMMANDS:
+            exe = bundle_root / program
+            if exe.exists():
+                self._runner([str(exe), *args], bundle_root)
+
+    @staticmethod
+    def _run_command(command: list[str], cwd: Path) -> None:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise RuntimeError(f"portable smoke command failed ({' '.join(command)}): {detail}")
+
+    @staticmethod
+    def _validate_module_manifests(bundle_root: Path) -> None:
+        for module_path in sorted(bundle_root.glob("gravityClientModule*.dll")):
+            manifest_path = bundle_root / f"{module_path.name}.manifest"
+            if not manifest_path.exists():
+                raise RuntimeError(f"portable bundle missing module manifest for {module_path.name}")
+
+    @staticmethod
+    def _validate_qt_runtime(bundle_root: Path) -> None:
+        has_qt_module = (bundle_root / "gravityClientModuleQtInProc.dll").exists()
+        has_qt_runtime = any((bundle_root / dll).exists() for dll in ("Qt6Core.dll", "Qt6Cored.dll"))
+        if has_qt_module or has_qt_runtime:
+            plugin_path = bundle_root / "platforms" / "qwindows.dll"
+            debug_plugin_path = bundle_root / "platforms" / "qwindowsd.dll"
+            if not plugin_path.exists() and not debug_plugin_path.exists():
+                raise RuntimeError("portable bundle missing Qt platform plugin under platforms/")

--- a/scripts/ci/release/smoke_portable_bundle.py
+++ b/scripts/ci/release/smoke_portable_bundle.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from python_tools.ci.release_bundle import ReleaseBundleSmokeValidator
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate and smoke-run a packaged portable Windows bundle.")
+    parser.add_argument("--archive", required=True, help="Portable bundle archive produced by package_bundle.py")
+    parser.add_argument(
+        "--extract-dir",
+        default="",
+        help="Optional extraction directory. Defaults to a sibling directory next to the archive.",
+    )
+    parser.add_argument(
+        "--layout-only",
+        action="store_true",
+        help="Validate extracted bundle contents without executing the packaged binaries.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    archive = Path(args.archive)
+    extract_dir = Path(args.extract_dir) if args.extract_dir.strip() else None
+    validator = ReleaseBundleSmokeValidator()
+    bundle_root = validator.validate_archive(archive, extract_dir=extract_dir, run_commands=not args.layout_only)
+    print(bundle_root.as_posix())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/checks/suites/release/test_release_outputs.py
+++ b/tests/checks/suites/release/test_release_outputs.py
@@ -7,7 +7,7 @@ import zipfile
 from pathlib import Path
 
 from python_tools.ci.numerical_validation import NumericalValidationCampaign
-from python_tools.ci.release_bundle import ReleaseBundlePackager
+from python_tools.ci.release_bundle import ReleaseBundlePackager, ReleaseBundleSmokeValidator
 from python_tools.ci.tool_manifest import ToolManifestCollector
 
 
@@ -60,16 +60,71 @@ def test_release_bundle_embeds_tool_manifest(tmp_path: Path, monkeypatch) -> Non
     build_dir = tmp_path / "build"
     build_dir.mkdir()
     (build_dir / "blitzar.exe").write_text("binary\n", encoding="utf-8")
+    (build_dir / "blitzar-client.exe").write_text("client\n", encoding="utf-8")
+    (build_dir / "gravityClientModuleQtInProc.dll").write_text("qt-module\n", encoding="utf-8")
+    (build_dir / "gravityClientModuleQtInProc.dll.manifest").write_text("manifest\n", encoding="utf-8")
+    (build_dir / "Qt6Core.dll").write_text("qt\n", encoding="utf-8")
+    (build_dir / "platforms").mkdir()
+    (build_dir / "platforms" / "qwindows.dll").write_text("plugin\n", encoding="utf-8")
     (tmp_path / "simulation.ini").write_text("config\n", encoding="utf-8")
     (tmp_path / "README.md").write_text("readme\n", encoding="utf-8")
     tool_manifest = tmp_path / "dist/tool-qualification/tool_manifest.json"
     tool_manifest.parent.mkdir(parents=True, exist_ok=True)
     tool_manifest.write_text('{"lane":"release"}\n', encoding="utf-8")
     archive = ReleaseBundlePackager().package(build_dir, tmp_path / "dist/release-bundle", "rc-1", tool_manifest)
+    assert archive.parent == tmp_path / "dist/release-bundle"
     with zipfile.ZipFile(archive) as bundle:
         names = bundle.namelist()
         assert "tool_manifest.json" in names
         assert "blitzar.exe" in names
+        assert "blitzar-client.exe" in names
+        assert "gravityClientModuleQtInProc.dll" in names
+        assert "gravityClientModuleQtInProc.dll.manifest" in names
+        assert "Qt6Core.dll" in names
+        assert "platforms/qwindows.dll" in names
+        assert archive.name not in names
+
+
+def test_release_bundle_smoke_validator_requires_qt_platform_plugin_for_qt_module(tmp_path: Path) -> None:
+    bundle_root = tmp_path / "bundle"
+    bundle_root.mkdir()
+    (bundle_root / "blitzar-client.exe").write_text("client\n", encoding="utf-8")
+    (bundle_root / "gravityClientModuleQtInProc.dll").write_text("qt-module\n", encoding="utf-8")
+    (bundle_root / "gravityClientModuleQtInProc.dll.manifest").write_text("manifest\n", encoding="utf-8")
+    (bundle_root / "Qt6Core.dll").write_text("qt\n", encoding="utf-8")
+    (bundle_root / "simulation.ini").write_text("config\n", encoding="utf-8")
+    (bundle_root / "README.md").write_text("readme\n", encoding="utf-8")
+
+    try:
+        ReleaseBundleSmokeValidator().validate_layout(bundle_root)
+        raise AssertionError("expected missing Qt platform plugin to fail validation")
+    except RuntimeError as error:
+        assert "platforms/" in str(error)
+
+
+def test_release_bundle_smoke_validator_runs_help_commands_for_present_binaries(tmp_path: Path) -> None:
+    bundle_root = tmp_path / "bundle"
+    bundle_root.mkdir()
+    for name in ("blitzar.exe", "blitzar-headless.exe", "blitzar-server.exe", "blitzar-client.exe"):
+        (bundle_root / name).write_text("exe\n", encoding="utf-8")
+    (bundle_root / "simulation.ini").write_text("config\n", encoding="utf-8")
+    (bundle_root / "README.md").write_text("readme\n", encoding="utf-8")
+    seen: list[tuple[list[str], Path]] = []
+
+    def _runner(command: list[str], cwd: Path) -> None:
+        seen.append((command, cwd))
+
+    validator = ReleaseBundleSmokeValidator(_runner)
+    validator.validate_layout(bundle_root)
+    validator.run_smoke(bundle_root)
+
+    assert [Path(command[0]).name for command, _ in seen] == [
+        "blitzar.exe",
+        "blitzar-headless.exe",
+        "blitzar-server.exe",
+        "blitzar-client.exe",
+    ]
+    assert all(cwd == bundle_root for _, cwd in seen)
 
 
 def test_tool_manifest_collector_records_versions_and_missing_tools(tmp_path: Path) -> None:


### PR DESCRIPTION
Implements #54

Closes #54

## Summary
- package adjacent Windows runtime DLLs, client-module manifests, and Qt plugin directories into the portable bundle
- smoke-validate the generated bundle after extraction in the release lane
- document the portable bundle behavior and cover the new packaging layout in release tests

## Validation
- python -m pytest -q tests/checks/suites/release/test_release_outputs.py
- python scripts/ci/release/package_bundle.py --build-dir build --dist-dir dist/release-bundle-local-smoke-2
- python scripts/ci/release/smoke_portable_bundle.py --archive dist/release-bundle-local-smoke-2/blitzar-manual-windows.zip --extract-dir dist/release-bundle-local-smoke-2-extracted
- make quality-local CONFIG=simulation.ini BUILD_DIR=build
- make quality-strict CONFIG=simulation.ini QUALITY_BUILD_DIR=build-quality-issue54 QUALITY_TIDY_JOBS=8