### PR TITLE
Issue #326: Expand protocol codec test coverage (+5% target)

### DIFF
--- a/TEST_EXPANSION_PLAN.md
+++ b/TEST_EXPANSION_PLAN.md
@@ -1,0 +1,189 @@
+# Test Expansion Plan for BLITZAR Coverage Improvement
+
+**Status**: Draft  
+**Date**: 2026-03-27  
+**Target Coverage**: Lines 47.6% → 65%, Functions 45.4% → 60%, Branches 32.8% → 50%
+
+---
+
+## 1. Current Coverage Analysis
+
+### Metrics (from coverage-data branch)
+| Metric | Current | Target | Gap |
+|--------|---------|--------|-----|
+| Lines | 47.6% | 65% | +17.4% |
+| Functions | 45.4% | 60% | +14.6% |
+| Branches | 32.8% | 50% | +17.2% |
+
+### Test Distribution
+| Area | Files | Tests | Ratio |
+|------|-------|-------|-------|
+| physics | 12 | (in tests/unit/physics) | ✅ Good |
+| protocol | 4 | (in tests/unit/protocol) | ⚠️ Low |
+| client | 2 | (in tests/unit/module_client) | ⚠️ Very Low |
+| config | 6 | (in tests/unit/config) | ✅ Good |
+| **Priority Areas** | | | |
+| engine/src/server | 2 cpp files | ~0 dedicated tests | ❌ Critical Gap |
+| runtime/src/protocol | 7 cpp files | ~1 test file | ❌ Critical Gap |
+| runtime/src/client | 11 cpp files | ~2 test files | ❌ Critical Gap |
+
+---
+
+## 2. Priority Expansion Areas (in order)
+
+### Phase 1: Protocol Stack (P0)
+**Target**: +8% line coverage, +12% branch coverage  
+**Scope**: runtime/src/protocol/*.cpp
+
+Files to test:
+- `ServerJsonCodec.cpp` (core serialization)
+- `ServerJsonCodecParse.cpp` (JSON parsing)
+- `ServerJsonCodecParseStatus.cpp` (status messages)
+- `ServerJsonCodecParseSnapshot.cpp` (snapshot parsing)
+- `ServerJsonCodecReadNumber.cpp` (number parsing)
+- `ServerProtocol.cpp` (protocol state machine)
+- `ServerClient.cpp` (client connection handling)
+
+Current test coverage: `tests/unit/protocol/json_codec.cpp` (~28 handlers)
+
+**Gaps to fill**:
+- ❌ Edge cases in number parsing (precision, overflow)
+- ❌ Malformed JSON error paths
+- ❌ Status message parsing variations
+- ❌ Snapshot data integrity validation
+- ❌ Connection state transitions
+- ❌ Protocol versioning compatibility
+
+**Estimated tests needed**: 40-60 new test cases
+
+---
+
+### Phase 2: Client Runtime (P1)
+**Target**: +5% line coverage  
+**Scope**: runtime/src/client/*.cpp
+
+Files to test:
+- `ClientModuleApi.cpp` (API entry points)
+- `ClientModuleBoundary.cpp` (boundary interface)
+- `ClientServerBridge.cpp` (bridge protocol)
+- `ClientRuntime.cpp` (runtime lifecycle)
+- `ErrorBuffer.cpp` (error handling)
+
+Current test coverage: Very sparse
+
+**Gaps to fill**:
+- ❌ Module loading/unloading lifecycle
+- ❌ Error propagation paths
+- ❌ Bridge command sequencing
+- ❌ Resource cleanup on failure
+
+**Estimated tests needed**: 25-35 new test cases
+
+---
+
+### Phase 3: Server Lifecycle (P2)
+**Target**: +4% line coverage  
+**Scope**: engine/src/server/*.cpp
+
+Files to test:
+- `SimulationServer.cpp` (server state machine) - 3501 lines, very complex
+- `SimulationInitConfig.cpp` (configuration handling)
+
+Current test coverage: Integrated tests only, no unit tests
+
+**Gaps to fill**:
+- ❌ Configuration parsing edge cases
+- ❌ Server initialization sequences
+- ❌ Error recovery paths
+- ❌ Resource allocation/deallocation
+
+**Note**: SimulationServer is too large (3501 lines) for unit tests. Defer to Lot C refactoring.  
+**Priority**: SimulationInitConfig only (~200 lines, testable)
+
+**Estimated tests needed**: 15-25 new test cases
+
+---
+
+## 3. Implementation Strategy
+
+### Batch 1: Protocol Codec Edge Cases (Quick Win)
+```
+Issue: #329 "Expand protocol codec test coverage"
+Branch: issue/329-protocol-codec-tests
+Scope: runtime/src/protocol (codec + parsing)
+Tests: 40-50 new cases
+Est. Coverage gain: +5-7% lines, +8-10% branches
+Timeline: 1 cycle
+```
+
+**Test categories**:
+1. Number parsing (float32 precision, NaN, Inf, denormalized)
+2. JSON malformation handling
+3. Status message state machine
+4. Snapshot binary format validation
+5. Connection lifecycle
+
+### Batch 2: Client Module Boundaries (Medium)
+```
+Issue: #330 "Improve client module test coverage"
+Branch: issue/330-client-module-tests
+Scope: runtime/src/client (API + lifecycle)
+Tests: 25-35 new cases
+Est. Coverage gain: +4-5% lines, +6-8% branches
+Timeline: 2 cycles
+```
+
+### Batch 3: Server Configuration (Supporting)
+```
+Issue: #331 "Add SimulationInitConfig unit tests"
+Branch: issue/331-server-config-tests
+Scope: engine/src/server (config only)
+Tests: 15-25 new cases
+Est. Coverage gain: +2-3% lines
+Timeline: 1 cycle
+```
+
+---
+
+## 4. Incremental Targets
+
+| Cycle | Batch | Target Lines | Target Functions | Target Branches | PR |
+|-------|-------|--------------|------------------|-----------------|-----|
+| Current | Baseline | 47.6% | 45.4% | 32.8% | #325 ✅ |
+| +1 | Protocol | 52-54% | 50-52% | 40-42% | #329 |
+| +2 | Client | 56-58% | 54-56% | 46-48% | #330 |
+| +3 | Config | 59-61% | 57-59% | 49-51% | #331 |
+| +4+ | Architectural | 65%+ | 60%+ | 50%+ | Future |
+
+---
+
+## 5. Quality Gates for New Tests
+
+Every test batch must satisfy:
+- ✅ All tests pass deterministically
+- ✅ No environment-dependent behavior
+- ✅ Coverage metrics increase by stated amount
+- ✅ Nightly workflow generates updated coverage report
+- ✅ Regression suite protected by tests (no fallback)
+- ✅ Anti-recurrence tests for newly covered paths
+
+---
+
+## 6. Next Step
+
+**Action**: Open issue #329 with Batch 1 scope (Protocol Codec)
+
+```
+Title: Expand protocol codec test coverage (+5% target)
+Labels: quality, testing
+Scope: runtime/src/protocol
+Target coverage gain: +5-7% lines, +8-10% branches
+Tests: 40-50 new cases covering number precision, JSON malformation, status parsing
+Timeline: 1 cycle
+```
+
+---
+
+**Owner**: AI Agent  
+**Status**: Ready for execution  
+**Decision Required**: Approve Batch 1 scope to open issue #329?

--- a/docs/quality/manifest/test_groups_core.json
+++ b/docs/quality/manifest/test_groups_core.json
@@ -1072,6 +1072,150 @@
                 "req_ids": [
                     "REQ-PROT-001"
                 ]
+            },
+            "TST-UNT-PROT-007": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_007_ParsesFloatPrecisionBoundaries",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-008": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_008_ParsesLargeNumericStatus",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-009": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_009_ParsesBoundaryNumericValues",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-010": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_010_ParsesExtremeEnergyStatus",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-011": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_011_RejectsMalformedJsonMissingOkField",
+                "req_ids": [
+                    "REQ-PROT-002"
+                ]
+            },
+            "TST-UNT-PROT-012": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_012_RejectsIncompleteJson",
+                "req_ids": [
+                    "REQ-PROT-002"
+                ]
+            },
+            "TST-UNT-PROT-013": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_013_RejectsWrongFieldTypes",
+                "req_ids": [
+                    "REQ-PROT-002"
+                ]
+            },
+            "TST-UNT-PROT-014": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_014_RejectsEmptyJsonObject",
+                "req_ids": [
+                    "REQ-PROT-002"
+                ]
+            },
+            "TST-UNT-PROT-015": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_015_RejectsInvalidJsonSyntax",
+                "req_ids": [
+                    "REQ-PROT-002"
+                ]
+            },
+            "TST-UNT-PROT-016": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_016_ParsesMinimalStatusPayload",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-017": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_017_ParsesAllBooleanFlagsTrue",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-018": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_018_ParsesAllBooleanFlagsFalse",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-019": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_019_ParsesStatusWithSpecialCharsInStrings",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-020": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_020_ParsesStatusWithEmptyStrings",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-021": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_021_ParsesSnapshotWithSingleParticle",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-022": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_022_ParsesSnapshotWithManyParticles",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-023": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_023_ParsesSnapshotUnavailable",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-024": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_024_ParsesSnapshotBoundaryCoordinates",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-025": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_025_RejectsSnapshotArrayMismatch",
+                "req_ids": [
+                    "REQ-PROT-002"
+                ]
+            },
+            "TST-UNT-PROT-026": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_026_CommandRequestWithEmptyToken",
+                "req_ids": [
+                    "REQ-PROT-002"
+                ]
+            },
+            "TST-UNT-PROT-027": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_027_CommandRequestWithLongToken",
+                "req_ids": [
+                    "REQ-PROT-002"
+                ]
+            },
+            "TST-UNT-PROT-028": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_028_ErrorResponseWithDifferentCommands",
+                "req_ids": [
+                    "REQ-PROT-002"
+                ]
+            },
+            "TST-UNT-PROT-029": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_029_StringEscapingRoundTrip",
+                "req_ids": [
+                    "REQ-PROT-001"
+                ]
+            },
+            "TST-UNT-PROT-030": {
+                "id": "ServerProtocolCodecTest.TST_UNT_PROT_030_ConsecutiveCommandResponseCycles",
+                "req_ids": [
+                    "REQ-PROT-002"
+                ]
             }
         },
         "EVD_TEST_UNIT_PROTOCOL_RUST": {

--- a/tests/unit/protocol/json_codec.cpp
+++ b/tests/unit/protocol/json_codec.cpp
@@ -162,4 +162,396 @@ TEST(ServerProtocolCodecTest, TST_UNT_PROT_005_ExportsCurrentSchemaVersionLabel)
     EXPECT_EQ(grav_protocol::SetSnapshotPublishCadence, "set_snapshot_publish_cadence");
 }
 
+// TST_UNT_PROT_007: Number parsing with maximum float32 precision
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_007_ParsesFloatPrecisionBoundaries)
+{
+    SimulationStats stats{};
+    stats.dt = 1.23456789f;  // High precision float
+    stats.totalTime = 0.00001f;  // Very small value
+    stats.serverFps = 144.5f;
+    stats.steps = 1u;
+
+    const std::string raw = grav_protocol::ServerJsonCodec::makeStatusResponse(stats);
+
+    grav_protocol::ServerStatusPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseStatusResponse(raw, parsed, error)) << error;
+    EXPECT_TRUE(parsed.envelope.ok);
+    EXPECT_FLOAT_EQ(parsed.dt, 1.23456789f);
+    EXPECT_FLOAT_EQ(parsed.totalTime, 0.00001f);
+}
+
+// TST_UNT_PROT_008: Very large numeric values in status
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_008_ParsesLargeNumericStatus)
+{
+    SimulationStats stats{};
+    stats.steps = 999999999u;
+    stats.particleCount = 1024u * 1024u;
+    stats.gpuVramTotalBytes = 16u * 1024u * 1024u * 1024u;
+    stats.totalTime = 1e6f;
+
+    const std::string raw = grav_protocol::ServerJsonCodec::makeStatusResponse(stats);
+
+    grav_protocol::ServerStatusPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseStatusResponse(raw, parsed, error)) << error;
+    EXPECT_EQ(parsed.steps, 999999999u);
+    EXPECT_EQ(parsed.particleCount, 1024u * 1024u);
+}
+
+// TST_UNT_PROT_009: Zero and boundary values in numeric fields
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_009_ParsesBoundaryNumericValues)
+{
+    SimulationStats stats{};
+    stats.dt = 0.0f;
+    stats.serverFps = 0.0f;
+    stats.kineticEnergy = -0.0f;
+    stats.substeps = 1u;
+
+    const std::string raw = grav_protocol::ServerJsonCodec::makeStatusResponse(stats);
+
+    grav_protocol::ServerStatusPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseStatusResponse(raw, parsed, error)) << error;
+    EXPECT_TRUE(parsed.envelope.ok);
+}
+
+// TST_UNT_PROT_010: Status with extreme energy values
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_010_ParsesExtremeEnergyStatus)
+{
+    SimulationStats stats{};
+    stats.kineticEnergy = 1e10f;
+    stats.potentialEnergy = -1e10f;
+    stats.thermalEnergy = 1e15f;
+    stats.totalEnergy = 1e15f;
+
+    const std::string raw = grav_protocol::ServerJsonCodec::makeStatusResponse(stats);
+
+    grav_protocol::ServerStatusPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseStatusResponse(raw, parsed, error)) << error;
+    EXPECT_TRUE(parsed.envelope.ok);
+}
+
+// TST_UNT_PROT_011: Rejects malformed JSON with missing required fields
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_011_RejectsMalformedJsonMissingOkField)
+{
+    const std::string raw = "{\"cmd\":\"set_solver\"}";  // Missing "ok" field
+
+    grav_protocol::ServerResponseEnvelope parsed{};
+    std::string error;
+    EXPECT_FALSE(grav_protocol::ServerJsonCodec::parseResponseEnvelope(raw, parsed, error));
+}
+
+// TST_UNT_PROT_012: Rejects incomplete JSON
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_012_RejectsIncompleteJson)
+{
+    const std::string raw = "{\"ok\":true,\"cmd\":\"get_status\"";  // Incomplete
+
+    grav_protocol::ServerStatusPayload parsed{};
+    std::string error;
+    EXPECT_FALSE(grav_protocol::ServerJsonCodec::parseStatusResponse(raw, parsed, error));
+}
+
+// TST_UNT_PROT_013: Rejects JSON with wrong field types
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_013_RejectsWrongFieldTypes)
+{
+    const std::string raw =
+        "{\"ok\":\"true\",\"cmd\":\"get_status\",\"steps\":\"not_a_number\"}";
+
+    grav_protocol::ServerStatusPayload parsed{};
+    std::string error;
+    EXPECT_FALSE(grav_protocol::ServerJsonCodec::parseStatusResponse(raw, parsed, error));
+}
+
+// TST_UNT_PROT_014: Handles empty JSON object
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_014_RejectsEmptyJsonObject)
+{
+    const std::string raw = "{}";
+
+    grav_protocol::ServerResponseEnvelope parsed{};
+    std::string error;
+    EXPECT_FALSE(grav_protocol::ServerJsonCodec::parseResponseEnvelope(raw, parsed, error));
+}
+
+// TST_UNT_PROT_015: Rejects invalid JSON syntax
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_015_RejectsInvalidJsonSyntax)
+{
+    const std::string raw = "{ok: true, cmd: 'get_status'}";  // Invalid: unquoted keys/values
+
+    grav_protocol::ServerResponseEnvelope parsed{};
+    std::string error;
+    EXPECT_FALSE(grav_protocol::ServerJsonCodec::parseResponseEnvelope(raw, parsed, error));
+}
+
+// TST_UNT_PROT_016: Status with minimal field set
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_016_ParsesMinimalStatusPayload)
+{
+    SimulationStats minimal_stats{};
+    minimal_stats.steps = 0u;
+
+    const std::string raw = grav_protocol::ServerJsonCodec::makeStatusResponse(minimal_stats);
+
+    grav_protocol::ServerStatusPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseStatusResponse(raw, parsed, error)) << error;
+    EXPECT_TRUE(parsed.envelope.ok);
+}
+
+// TST_UNT_PROT_017: Status with all boolean flags set to true
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_017_ParsesAllBooleanFlagsTrue)
+{
+    SimulationStats stats{};
+    stats.paused = true;
+    stats.faulted = true;
+    stats.sphEnabled = true;
+    stats.energyEstimated = true;
+    stats.gpuTelemetryEnabled = true;
+    stats.gpuTelemetryAvailable = true;
+    stats.exportActive = true;
+
+    const std::string raw = grav_protocol::ServerJsonCodec::makeStatusResponse(stats);
+
+    grav_protocol::ServerStatusPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseStatusResponse(raw, parsed, error)) << error;
+    EXPECT_TRUE(parsed.paused);
+    EXPECT_TRUE(parsed.faulted);
+    EXPECT_TRUE(parsed.sphEnabled);
+    EXPECT_TRUE(parsed.energyEstimated);
+}
+
+// TST_UNT_PROT_018: Status with all boolean flags set to false
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_018_ParsesAllBooleanFlagsFalse)
+{
+    SimulationStats stats{};
+    stats.paused = false;
+    stats.faulted = false;
+    stats.sphEnabled = false;
+    stats.energyEstimated = false;
+    stats.gpuTelemetryEnabled = false;
+    stats.gpuTelemetryAvailable = false;
+    stats.exportActive = false;
+
+    const std::string raw = grav_protocol::ServerJsonCodec::makeStatusResponse(stats);
+
+    grav_protocol::ServerStatusPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseStatusResponse(raw, parsed, error)) << error;
+    EXPECT_FALSE(parsed.paused);
+    EXPECT_FALSE(parsed.faulted);
+}
+
+// TST_UNT_PROT_019: Status with special characters in string fields
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_019_ParsesStatusWithSpecialCharsInStrings)
+{
+    SimulationStats stats{};
+    stats.faultReason = "error\nwith\\special\"chars\rhere";
+    stats.exportLastState = "idle\t\ttab";
+    stats.exportLastMessage = "message with \"quotes\" and 'apostrophes'";
+
+    const std::string raw = grav_protocol::ServerJsonCodec::makeStatusResponse(stats);
+
+    grav_protocol::ServerStatusPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseStatusResponse(raw, parsed, error)) << error;
+    EXPECT_TRUE(parsed.envelope.ok);
+}
+
+// TST_UNT_PROT_020: Empty strings in status fields
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_020_ParsesStatusWithEmptyStrings)
+{
+    SimulationStats stats{};
+    stats.faultReason = "";
+    stats.performanceProfile = "";
+    stats.solverName = "";
+    stats.integratorName = "";
+    stats.exportLastMessage = "";
+
+    const std::string raw = grav_protocol::ServerJsonCodec::makeStatusResponse(stats);
+
+    grav_protocol::ServerStatusPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseStatusResponse(raw, parsed, error)) << error;
+    EXPECT_TRUE(parsed.envelope.ok);
+}
+
+// TST_UNT_PROT_021: Snapshot with single particle
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_021_ParsesSnapshotWithSingleParticle)
+{
+    std::vector<RenderParticle> snapshot(1u);
+    snapshot[0].x = 1.0f;
+    snapshot[0].y = 2.0f;
+    snapshot[0].z = 3.0f;
+    snapshot[0].mass = 4.0f;
+    snapshot[0].pressureNorm = 0.1f;
+    snapshot[0].temperature = 0.3f;
+
+    const std::string raw = grav_protocol::ServerJsonCodec::makeSnapshotResponse(true, snapshot, 1u);
+
+    grav_protocol::ServerSnapshotPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseSnapshotResponse(raw, parsed, error)) << error;
+    EXPECT_EQ(parsed.particles.size(), 1u);
+    EXPECT_EQ(parsed.sourceSize, 1u);
+}
+
+// TST_UNT_PROT_022: Snapshot with many particles
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_022_ParsesSnapshotWithManyParticles)
+{
+    std::vector<RenderParticle> snapshot(1000u);
+    for (size_t i = 0u; i < snapshot.size(); ++i) {
+        snapshot[i].x = static_cast<float>(i);
+        snapshot[i].y = static_cast<float>(i + 1u);
+        snapshot[i].z = static_cast<float>(i + 2u);
+    }
+
+    const std::string raw = grav_protocol::ServerJsonCodec::makeSnapshotResponse(true, snapshot, 1000u);
+
+    grav_protocol::ServerSnapshotPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseSnapshotResponse(raw, parsed, error)) << error;
+    EXPECT_EQ(parsed.particles.size(), 1000u);
+    EXPECT_EQ(parsed.sourceSize, 1000u);
+}
+
+// TST_UNT_PROT_023: Snapshot with no snapshot data available
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_023_ParsesSnapshotUnavailable)
+{
+    std::vector<RenderParticle> empty_snapshot;
+    const std::string raw = grav_protocol::ServerJsonCodec::makeSnapshotResponse(false, empty_snapshot, 0u);
+
+    grav_protocol::ServerSnapshotPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseSnapshotResponse(raw, parsed, error)) << error;
+    EXPECT_FALSE(parsed.hasSnapshot);
+    EXPECT_EQ(parsed.particles.size(), 0u);
+}
+
+// TST_UNT_PROT_024: Snapshot with boundary coordinate values
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_024_ParsesSnapshotBoundaryCoordinates)
+{
+    std::vector<RenderParticle> snapshot(3u);
+    snapshot[0].x = 0.0f;
+    snapshot[0].y = 0.0f;
+    snapshot[0].z = 0.0f;
+    snapshot[1].x = 1e6f;
+    snapshot[1].y = -1e6f;
+    snapshot[1].z = 1e-6f;
+    snapshot[2].x = -1e6f;
+    snapshot[2].y = 1e6f;
+    snapshot[2].z = -1e-6f;
+
+    const std::string raw = grav_protocol::ServerJsonCodec::makeSnapshotResponse(true, snapshot, 3u);
+
+    grav_protocol::ServerSnapshotPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseSnapshotResponse(raw, parsed, error)) << error;
+    ASSERT_EQ(parsed.particles.size(), 3u);
+    EXPECT_FLOAT_EQ(parsed.particles[0].x, 0.0f);
+    EXPECT_FLOAT_EQ(parsed.particles[1].x, 1e6f);
+}
+
+// TST_UNT_PROT_025: Rejects snapshot with mismatched particle count
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_025_RejectsSnapshotArrayMismatch)
+{
+    // Manually craft JSON with mismatch between count and actual array size
+    const std::string raw =
+        "{\"ok\":true,\"cmd\":\"get_snapshot\",\"has_snapshot\":true,\"count\":10,"
+        "\"particles\":[[1,2,3,4,5,6,7]]}";  // Only 1 particle, but count says 10
+
+    grav_protocol::ServerSnapshotPayload parsed{};
+    std::string error;
+    EXPECT_FALSE(grav_protocol::ServerJsonCodec::parseSnapshotResponse(raw, parsed, error));
+}
+
+// TST_UNT_PROT_026: Command request round-trip with empty token
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_026_CommandRequestWithEmptyToken)
+{
+    grav_protocol::ServerCommandRequest request{};
+    request.cmd = std::string(grav_protocol::SetSolver);
+    request.token = "";
+
+    const std::string json = grav_protocol::ServerJsonCodec::makeCommandRequest(
+        request,
+        "\"value\":\"octree_gpu\"");
+
+    grav_protocol::ServerCommandRequest parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseCommandRequest(json, parsed, error)) << error;
+    EXPECT_EQ(parsed.token, "");
+}
+
+// TST_UNT_PROT_027: Command request with very long token
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_027_CommandRequestWithLongToken)
+{
+    grav_protocol::ServerCommandRequest request{};
+    request.cmd = std::string(grav_protocol::SetSolver);
+    request.token = std::string(1000u, 'x');
+
+    const std::string json = grav_protocol::ServerJsonCodec::makeCommandRequest(
+        request,
+        "\"value\":\"octree_gpu\"");
+
+    grav_protocol::ServerCommandRequest parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseCommandRequest(json, parsed, error)) << error;
+    EXPECT_EQ(parsed.token.size(), 1000u);
+}
+
+// TST_UNT_PROT_028: Error response with various command types
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_028_ErrorResponseWithDifferentCommands)
+{
+    const auto test_command = [](std::string_view cmd) {
+        const std::string raw = grav_protocol::ServerJsonCodec::makeErrorResponse(cmd, "test error");
+
+        grav_protocol::ServerResponseEnvelope parsed{};
+        std::string error;
+        EXPECT_TRUE(grav_protocol::ServerJsonCodec::parseResponseEnvelope(raw, parsed, error)) << error;
+        EXPECT_FALSE(parsed.ok);
+        EXPECT_EQ(parsed.cmd, cmd);
+        EXPECT_EQ(parsed.error, "test error");
+    };
+
+    test_command(grav_protocol::SetSolver);
+    test_command(grav_protocol::SetIntegrator);
+    test_command(grav_protocol::Status);
+    test_command(grav_protocol::GetSnapshot);
+}
+
+// TST_UNT_PROT_029: String escaping preserves all special sequences
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_029_StringEscapingRoundTrip)
+{
+    SimulationStats stats{};
+    stats.faultReason = "Complex: \\ \" \n \r \t special";
+
+    const std::string raw = grav_protocol::ServerJsonCodec::makeStatusResponse(stats);
+
+    grav_protocol::ServerStatusPayload parsed{};
+    std::string error;
+    ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseStatusResponse(raw, parsed, error)) << error;
+    EXPECT_EQ(parsed.faultReason, "Complex: \\ \" \n \r \t special");
+}
+
+// TST_UNT_PROT_030: Consecutive rapid command-response cycles
+TEST(ServerProtocolCodecTest, TST_UNT_PROT_030_ConsecutiveCommandResponseCycles)
+{
+    for (int i = 0; i < 10; ++i) {
+        grav_protocol::ServerCommandRequest request{};
+        request.cmd = std::string(grav_protocol::SetSolver);
+        request.token = "token_" + std::to_string(i);
+
+        const std::string json = grav_protocol::ServerJsonCodec::makeCommandRequest(request, "\"value\":\"octree_gpu\"");
+
+        grav_protocol::ServerCommandRequest parsed{};
+        std::string error;
+        ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseCommandRequest(json, parsed, error)) << error;
+
+        const std::string response = grav_protocol::ServerJsonCodec::makeOkResponse(grav_protocol::SetSolver);
+        grav_protocol::ServerResponseEnvelope parsed_resp{};
+        ASSERT_TRUE(grav_protocol::ServerJsonCodec::parseResponseEnvelope(response, parsed_resp, error)) << error;
+        EXPECT_TRUE(parsed_resp.ok);
+    }
+}
+
 } // namespace grav_test_protocol_codec


### PR DESCRIPTION
Implements #326

## Summary
Expanded protocol codec test coverage by adding 24 comprehensive new test cases targeting:
- Number parsing precision and boundary values
- JSON malformation detection
- Status message parsing variations
- Snapshot validation edge cases
- Command request lifecycle

## Test IDs
- TST-UNT-PROT-007 through TST-UNT-PROT-030 (24 new tests)

## Target Improvement
- Lines: 47.6% → 52-54% (+5-7%)
- Branches: 32.8% → 40-42% (+8-10%)

## Changes
- Added 24 new test cases to tests/unit/protocol/json_codec.cpp
- Updated docs/quality/manifest/test_groups_core.json with test registry
- All tests follow normalized ID format (TST-UNT-PROT-XXX)
- All tests deterministic and environment-independent

Closes #326