### PR TITLE
Issue #408: Handle directory evidence entries

### DIFF
--- a/python_tools/ci/release_evidence_pack.py
+++ b/python_tools/ci/release_evidence_pack.py
@@ -146,7 +146,10 @@ class ReleaseEvidencePackager:
             source = root / item["path"]
             destination = evidence_root / item["path"]
             destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source, destination)
+            if source.is_dir():
+                shutil.copytree(source, destination, dirs_exist_ok=True)
+            else:
+                shutil.copy2(source, destination)
         archive_base = dist_dir / f"ASTER-{tag}-evidence"
         return Path(shutil.make_archive(str(archive_base), "zip", root_dir=dist_dir))
 

--- a/tests/checks/suites/release/test_release_evidence.py
+++ b/tests/checks/suites/release/test_release_evidence.py
@@ -45,6 +45,7 @@ def _seed_repo(root: Path) -> None:
                 "EVD_SCRIPT_RELEASE_PACKAGE_SBOM": "scripts/ci/release/package_sbom.py",
                 "EVD_SCRIPT_RELEASE_PACKAGE_SOURCE": "scripts/ci/release/package_source.py",
                 "EVD_SAMPLE": "docs/quality/sample_requirement.md",
+                "EVD_SAMPLE_DIR": "tests/unit/ffi",
             }
         },
     )
@@ -52,7 +53,7 @@ def _seed_repo(root: Path) -> None:
         root / "docs/quality/manifest/requirements.json",
         {
             "requirements": {
-                "REQ-TEST-001": {"tests": ["^TST_ONE$"], "artifacts": ["EVD_SAMPLE"]},
+                "REQ-TEST-001": {"tests": ["^TST_ONE$"], "artifacts": ["EVD_SAMPLE", "EVD_SAMPLE_DIR"]},
                 "REQ-TEST-002": {"tests": ["^TST_TWO$"], "artifacts": ["EVD_SAMPLE"]},
             }
         },
@@ -95,6 +96,7 @@ def _seed_repo(root: Path) -> None:
         "scripts/ci/release/package_quality_index.py",
         "scripts/ci/release/package_sbom.py",
         "scripts/ci/release/package_source.py",
+        "tests/unit/ffi/test_stub.cpp",
     ]:
         _write_text(root / rel)
 
@@ -125,6 +127,7 @@ def test_release_evidence_packager_packages_selected_requirements(tmp_path: Path
     assert payload["open_exceptions"][0]["id"] == "DEV-QUAL-001"
     assert payload["open_exceptions"][0]["paths"] == ["engine/src/server/SimulationServer.cpp"]
     assert "evidence/docs/quality/sample_requirement.md" in names
+    assert "evidence/tests/unit/ffi/test_stub.cpp" in names
     assert "README.md" in names
 
 


### PR DESCRIPTION
Implements #408\n\nCloses #408\n\nRequirements impacted:\n- Release evidence packaging / quality evidence path\n\n- [x] Analyzer evidence attached\n- [x] Deterministic test evidence attached\n- [x] Deviation recorded or not needed\n- [x] Solo maintainer waiver recorded\n\nAnalyzer evidence: python tests/checks/check.py all --root . --config simulation.ini; git diff --check; make quality-local CONFIG=simulation.ini; make quality-strict CONFIG=simulation.ini QUALITY_BUILD_DIR=build-quality\nDeterministic test evidence: python -m pytest tests/checks/suites/release/test_release_evidence.py; python scripts/ci/release/package_evidence.py --root . --dist-dir dist/evidence-pack-local --profile prod --tag v0.1.0-rc.1\nRelease failure reference: release-lane run 24958074499 failed in Package release evidence because tests/unit/ffi is a directory copied with shutil.copy2.\nIndependent reviewer: none (solo maintainer waiver)\nSolo maintainer waiver: true\nDeviation: DEV-SOLO-IVV