### PR TITLE
Restore owner references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,11 @@
 # IV&V ownership for mission-impacting paths.
 # Approval must come from a non-author reviewer and is enforced by the PR IV&V gate.
+
+docs/server-protocol.md @Luis1454
+docs/quality/numerical-validation.md @Luis1454
+engine/include/physics/ @Luis1454
+engine/src/physics/ @Luis1454
+runtime/ @Luis1454
+tests/int/protocol/ @Luis1454
+tests/int/runtime/ @Luis1454
+tests/unit/physics/ @Luis1454

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # @file CMakeLists.txt
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Source artifact for the BLITZAR simulation project.
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # @file Makefile
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Source artifact for the BLITZAR simulation project.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # BLITZAR
 ### Baryonic Lagrangian Integration of Trajectories for Zero-drift Astrophysical Research
 
+[![nightly-full](https://github.com/Luis1454/BLITZAR/actions/workflows/nightly-full.yml/badge.svg?branch=main)](https://github.com/Luis1454/BLITZAR/actions/workflows/nightly-full.yml)
+[![Coverage lines](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FLuis1454%2FBLITZAR%2Fcoverage-data%2Fcoverage%2Flines.json)](https://github.com/Luis1454/BLITZAR/tree/coverage-data/coverage)
+[![Coverage functions](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FLuis1454%2FBLITZAR%2Fcoverage-data%2Fcoverage%2Ffunctions.json)](https://github.com/Luis1454/BLITZAR/tree/coverage-data/coverage)
+[![Coverage branches](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FLuis1454%2FBLITZAR%2Fcoverage-data%2Fcoverage%2Fbranches.json)](https://github.com/Luis1454/BLITZAR/tree/coverage-data/coverage)
+
 > **High-Performance GPGPU N-Body Engine simulating 100M+ particles with NASA-standard fidelity.**
-> Demo media: `docs/media/`
+> [Insert demo video or simulation GIF](https://github.com/Luis1454/BLITZAR)
 
 ## Scientific & Performance Core
 
@@ -15,6 +20,8 @@ While the repository follows strict software engineering gates, BLITZAR is at it
 ## Operational Control & Quality
 
 Coverage is treated as a first-class steering signal for execution risk, alongside deterministic tests and issue state transitions.
+
+[![Coverage control widget](https://raw.githubusercontent.com/Luis1454/BLITZAR/coverage-data/coverage/widget.svg)](https://github.com/Luis1454/BLITZAR/tree/coverage-data/coverage)
 
 - Operational framework: [docs/quality/operational-control.md](docs/quality/operational-control.md)
 - Coverage dashboard payload: `coverage-data/coverage/*`

--- a/apps/client-host/include/Cli.hpp
+++ b/apps/client-host/include/Cli.hpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/client-host/include/Cli.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/apps/client-host/include/CliArgs.hpp
+++ b/apps/client-host/include/CliArgs.hpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/client-host/include/CliArgs.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/apps/client-host/include/CliText.hpp
+++ b/apps/client-host/include/CliText.hpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/client-host/include/CliText.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/apps/client-host/include/ModuleOps.hpp
+++ b/apps/client-host/include/ModuleOps.hpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/client-host/include/ModuleOps.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/apps/client-host/src/Cli.cpp
+++ b/apps/client-host/src/Cli.cpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/client-host/src/Cli.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/apps/client-host/src/CliArgs.cpp
+++ b/apps/client-host/src/CliArgs.cpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/client-host/src/CliArgs.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/apps/client-host/src/CliText.cpp
+++ b/apps/client-host/src/CliText.cpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/client-host/src/CliText.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/apps/client-host/src/ModuleOps.cpp
+++ b/apps/client-host/src/ModuleOps.cpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/client-host/src/ModuleOps.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/apps/client-host/src/main.cpp
+++ b/apps/client-host/src/main.cpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/client-host/src/main.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/apps/headless/src/main.cpp
+++ b/apps/headless/src/main.cpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/headless/src/main.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Headless simulation entry point.
  */

--- a/apps/headless/src/main.cu
+++ b/apps/headless/src/main.cu
@@ -1,6 +1,6 @@
 /*
  * @file apps/headless/src/main.cu
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/apps/launcher/src/main.cpp
+++ b/apps/launcher/src/main.cpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/launcher/src/main.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/apps/server-service/include/Args.hpp
+++ b/apps/server-service/include/Args.hpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/server-service/include/Args.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/apps/server-service/src/Args.cpp
+++ b/apps/server-service/src/Args.cpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/server-service/src/Args.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/apps/server-service/src/main.cpp
+++ b/apps/server-service/src/main.cpp
@@ -1,6 +1,6 @@
 /*
  * @file apps/server-service/src/main.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Application entry points and host executables for BLITZAR.
  */

--- a/cmake/apps.cmake
+++ b/cmake/apps.cmake
@@ -1,5 +1,5 @@
 # @file cmake/apps.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief CMake build orchestration for BLITZAR targets and tooling.
 

--- a/cmake/clang-format-runner.cmake
+++ b/cmake/clang-format-runner.cmake
@@ -1,5 +1,5 @@
 # @file cmake/clang-format-runner.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief CMake build orchestration for BLITZAR targets and tooling.
 

--- a/cmake/core.cmake
+++ b/cmake/core.cmake
@@ -1,5 +1,5 @@
 # @file cmake/core.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief CMake build orchestration for BLITZAR targets and tooling.
 

--- a/cmake/core/clang-format.cmake
+++ b/cmake/core/clang-format.cmake
@@ -1,5 +1,5 @@
 # @file cmake/core/clang-format.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief CMake build orchestration for BLITZAR targets and tooling.
 

--- a/cmake/core/profile.cmake
+++ b/cmake/core/profile.cmake
@@ -1,5 +1,5 @@
 # @file cmake/core/profile.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief CMake build orchestration for BLITZAR targets and tooling.
 

--- a/cmake/core/targets.cmake
+++ b/cmake/core/targets.cmake
@@ -1,5 +1,5 @@
 # @file cmake/core/targets.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief CMake build orchestration for BLITZAR targets and tooling.
 

--- a/cmake/core/toolchain.cmake
+++ b/cmake/core/toolchain.cmake
@@ -1,5 +1,5 @@
 # @file cmake/core/toolchain.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief CMake build orchestration for BLITZAR targets and tooling.
 

--- a/cmake/qt_runtime_deploy.cmake
+++ b/cmake/qt_runtime_deploy.cmake
@@ -1,5 +1,5 @@
 # @file cmake/qt_runtime_deploy.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief CMake build orchestration for BLITZAR targets and tooling.
 

--- a/cmake/rust.cmake
+++ b/cmake/rust.cmake
@@ -1,5 +1,5 @@
 # @file cmake/rust.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief CMake build orchestration for BLITZAR targets and tooling.
 

--- a/cmake/targets.cmake
+++ b/cmake/targets.cmake
@@ -1,5 +1,5 @@
 # @file cmake/targets.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief CMake build orchestration for BLITZAR targets and tooling.
 

--- a/cmake/win.cmake
+++ b/cmake/win.cmake
@@ -1,5 +1,5 @@
 # @file cmake/win.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief CMake build orchestration for BLITZAR targets and tooling.
 

--- a/docs/quality/gpu-runner-operations.md
+++ b/docs/quality/gpu-runner-operations.md
@@ -23,7 +23,7 @@ Use the extracted `actions-runner` directory on the Windows host, then run:
 
 ```powershell
 python scripts/ci/gpu/bootstrap_windows_runner.py `
-  --repo OWNER/BLITZAR `
+  --repo Luis1454/BLITZAR `
   --runner-root C:\actions-runner `
   --runner-name blitzar-gpu-01 `
   --output dist/gpu-runner/bootstrap-plan.json `

--- a/engine/include/config/args/ClientOptions.hpp
+++ b/engine/include/config/args/ClientOptions.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/args/ClientOptions.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/args/CoreOptions.hpp
+++ b/engine/include/config/args/CoreOptions.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/args/CoreOptions.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/args/FluidOptions.hpp
+++ b/engine/include/config/args/FluidOptions.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/args/FluidOptions.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/args/InitOptions.hpp
+++ b/engine/include/config/args/InitOptions.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/args/InitOptions.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/args/InitStateOptions.hpp
+++ b/engine/include/config/args/InitStateOptions.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/args/InitStateOptions.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/args/Main.hpp
+++ b/engine/include/config/args/Main.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/args/Main.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/args/Parse.hpp
+++ b/engine/include/config/args/Parse.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/args/Parse.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/core/Config.hpp
+++ b/engine/include/config/core/Config.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/core/Config.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/directive/Config.hpp
+++ b/engine/include/config/directive/Config.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/directive/Config.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/directive/StreamWriter.hpp
+++ b/engine/include/config/directive/StreamWriter.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/directive/StreamWriter.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/directive/ValueFormatter.hpp
+++ b/engine/include/config/directive/ValueFormatter.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/directive/ValueFormatter.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/directive/Write.hpp
+++ b/engine/include/config/directive/Write.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/directive/Write.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/env/Base.hpp
+++ b/engine/include/config/env/Base.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/env/Base.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/modes/Normalize.hpp
+++ b/engine/include/config/modes/Normalize.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/modes/Normalize.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/profile/Main.hpp
+++ b/engine/include/config/profile/Main.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/profile/Main.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/profile/Performance.hpp
+++ b/engine/include/config/profile/Performance.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/profile/Performance.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/registry/Main.hpp
+++ b/engine/include/config/registry/Main.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/registry/Main.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/text/Parse.hpp
+++ b/engine/include/config/text/Parse.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/text/Parse.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/validation/Physics.hpp
+++ b/engine/include/config/validation/Physics.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/validation/Physics.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/validation/Render.hpp
+++ b/engine/include/config/validation/Render.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/validation/Render.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/config/validation/Scenario.hpp
+++ b/engine/include/config/validation/Scenario.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/config/validation/Scenario.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public configuration interfaces and validation contracts for simulation setup.
  */

--- a/engine/include/graphics/ColorPipeline.hpp
+++ b/engine/include/graphics/ColorPipeline.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/graphics/ColorPipeline.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/include/graphics/GraphicsTypes.hpp
+++ b/engine/include/graphics/GraphicsTypes.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/graphics/GraphicsTypes.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/include/graphics/ViewMath.hpp
+++ b/engine/include/graphics/ViewMath.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/graphics/ViewMath.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/include/physics/ForceLawPolicy.hpp
+++ b/engine/include/physics/ForceLawPolicy.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/physics/ForceLawPolicy.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public physics interfaces and data contracts for deterministic simulation kernels.
  */

--- a/engine/include/physics/Gpu.hpp
+++ b/engine/include/physics/Gpu.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/physics/Gpu.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public physics interfaces and data contracts for deterministic simulation kernels.
  */

--- a/engine/include/physics/Octree.hpp
+++ b/engine/include/physics/Octree.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/physics/Octree.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public physics interfaces and data contracts for deterministic simulation kernels.
  */

--- a/engine/include/physics/Particle.hpp
+++ b/engine/include/physics/Particle.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/physics/Particle.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public physics interfaces and data contracts for deterministic simulation kernels.
  */

--- a/engine/include/physics/Particle.inl
+++ b/engine/include/physics/Particle.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/physics/Particle.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Inline host/device particle operations shared by CPU and CUDA builds.
  */

--- a/engine/include/physics/ParticleHotData.hpp
+++ b/engine/include/physics/ParticleHotData.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/physics/ParticleHotData.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Cache-optimized particle data for force computation hotpath.
  */

--- a/engine/include/physics/ParticleSoAView.hpp
+++ b/engine/include/physics/ParticleSoAView.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/physics/ParticleSoAView.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public physics interfaces and data contracts for deterministic simulation kernels.
  */

--- a/engine/include/physics/ParticleSoAView.inl
+++ b/engine/include/physics/ParticleSoAView.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/physics/ParticleSoAView.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public physics interfaces and data contracts for deterministic simulation kernels.
  */

--- a/engine/include/physics/ParticleSystem.hpp
+++ b/engine/include/physics/ParticleSystem.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/physics/ParticleSystem.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public physics interfaces and data contracts for deterministic simulation kernels.
  */

--- a/engine/include/physics/Vector.hpp
+++ b/engine/include/physics/Vector.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/physics/Vector.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public physics interfaces and data contracts for deterministic simulation kernels.
  */

--- a/engine/include/physics/Vector.inl
+++ b/engine/include/physics/Vector.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/physics/Vector.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public physics interfaces and data contracts for deterministic simulation kernels.
  */

--- a/engine/include/platform/DynamicLibrary.hpp
+++ b/engine/include/platform/DynamicLibrary.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/platform/DynamicLibrary.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction interfaces for portable runtime services.
  */

--- a/engine/include/platform/Errors.hpp
+++ b/engine/include/platform/Errors.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/platform/Errors.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction interfaces for portable runtime services.
  */

--- a/engine/include/platform/Paths.hpp
+++ b/engine/include/platform/Paths.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/platform/Paths.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction interfaces for portable runtime services.
  */

--- a/engine/include/platform/Process.hpp
+++ b/engine/include/platform/Process.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/platform/Process.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction interfaces for portable runtime services.
  */

--- a/engine/include/platform/Socket.hpp
+++ b/engine/include/platform/Socket.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/platform/Socket.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction interfaces for portable runtime services.
  */

--- a/engine/include/platform/internal/DynamicLibraryOps.hpp
+++ b/engine/include/platform/internal/DynamicLibraryOps.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/platform/internal/DynamicLibraryOps.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction interfaces for portable runtime services.
  */

--- a/engine/include/platform/internal/ProcessOps.hpp
+++ b/engine/include/platform/internal/ProcessOps.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/platform/internal/ProcessOps.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction interfaces for portable runtime services.
  */

--- a/engine/include/platform/internal/SocketOps.hpp
+++ b/engine/include/platform/internal/SocketOps.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/platform/internal/SocketOps.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction interfaces for portable runtime services.
  */

--- a/engine/include/server/SimulationInitConfig.hpp
+++ b/engine/include/server/SimulationInitConfig.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/server/SimulationInitConfig.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/include/server/SimulationServer.hpp
+++ b/engine/include/server/SimulationServer.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/server/SimulationServer.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/include/types/SimulationTypes.hpp
+++ b/engine/include/types/SimulationTypes.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/include/types/SimulationTypes.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/config/args/ClientOptions.cpp
+++ b/engine/src/config/args/ClientOptions.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/args/ClientOptions.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/args/CoreOptions.cpp
+++ b/engine/src/config/args/CoreOptions.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/args/CoreOptions.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/args/FluidOptions.cpp
+++ b/engine/src/config/args/FluidOptions.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/args/FluidOptions.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/args/InitOptions.cpp
+++ b/engine/src/config/args/InitOptions.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/args/InitOptions.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/args/InitStateOptions.cpp
+++ b/engine/src/config/args/InitStateOptions.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/args/InitStateOptions.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/args/Main.cpp
+++ b/engine/src/config/args/Main.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/SimulationArgs.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/args/Parse.cpp
+++ b/engine/src/config/args/Parse.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/SimulationArgsParse.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/core/Config.cpp
+++ b/engine/src/config/core/Config.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/SimulationConfig.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/directive/Config.cpp
+++ b/engine/src/config/directive/Config.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/SimulationConfigDirective.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/directive/StreamWriter.cpp
+++ b/engine/src/config/directive/StreamWriter.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/DirectiveStreamWriter.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/directive/ValueFormatter.cpp
+++ b/engine/src/config/directive/ValueFormatter.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/directive/ValueFormatter.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/directive/Write.cpp
+++ b/engine/src/config/directive/Write.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/SimulationConfigDirectiveWrite.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/env/Base.cpp
+++ b/engine/src/config/env/Base.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/EnvUtils.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/env/Posix.cpp
+++ b/engine/src/config/env/Posix.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/EnvUtilsPosix.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/env/Win.cpp
+++ b/engine/src/config/env/Win.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/EnvUtilsWin.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/modes/Normalize.cpp
+++ b/engine/src/config/modes/Normalize.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/SimulationModes.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/profile/Main.cpp
+++ b/engine/src/config/profile/Main.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/SimulationProfile.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/profile/Performance.cpp
+++ b/engine/src/config/profile/Performance.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/SimulationPerformanceProfile.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/registry/Apply.cpp
+++ b/engine/src/config/registry/Apply.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/SimulationOptionRegistryApply.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/registry/Entries.cpp
+++ b/engine/src/config/registry/Entries.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/SimulationOptionRegistryEntries.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/registry/Internal.hpp
+++ b/engine/src/config/registry/Internal.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/Internal.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/registry/Main.cpp
+++ b/engine/src/config/registry/Main.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/SimulationOptionRegistry.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/text/Parse.cpp
+++ b/engine/src/config/text/Parse.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/TextParse.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/validation/Physics.cpp
+++ b/engine/src/config/validation/Physics.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/validation/Physics.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/validation/Render.cpp
+++ b/engine/src/config/validation/Render.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/validation/Render.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/config/validation/Scenario.cpp
+++ b/engine/src/config/validation/Scenario.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/config/SimulationScenarioValidation.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Configuration parsing, validation, and serialization implementation.
  */

--- a/engine/src/cuda/MemoryPool.cu
+++ b/engine/src/cuda/MemoryPool.cu
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/MemoryPool.cu
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/MemoryPool.hpp
+++ b/engine/src/cuda/MemoryPool.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/MemoryPool.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Public physics interfaces and data contracts for deterministic simulation kernels.
  */

--- a/engine/src/cuda/ParticleSystem.cu
+++ b/engine/src/cuda/ParticleSystem.cu
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/ParticleSystem.cu
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/TestKernel.cu
+++ b/engine/src/cuda/TestKernel.cu
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/TestKernel.cu
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/integration/TiledAcceleration.inl
+++ b/engine/src/cuda/fragments/integration/TiledAcceleration.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/integration/TiledAcceleration.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/integration/Update.inl
+++ b/engine/src/cuda/fragments/integration/Update.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/integration/Update.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/octree/Build.inl
+++ b/engine/src/cuda/fragments/octree/Build.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/octree/Build.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/octree/Force.inl
+++ b/engine/src/cuda/fragments/octree/Force.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/octree/Force.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/octree/Gpu.inl
+++ b/engine/src/cuda/fragments/octree/Gpu.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/octree/Gpu.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/octree/Impl.inl
+++ b/engine/src/cuda/fragments/octree/Impl.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/octree/Impl.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/octree/LinearGpu.inl
+++ b/engine/src/cuda/fragments/octree/LinearGpu.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/octree/LinearGpu.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/octree/MortonSorting.inl
+++ b/engine/src/cuda/fragments/octree/MortonSorting.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/octree/MortonSorting.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/sph/Grid.inl
+++ b/engine/src/cuda/fragments/sph/Grid.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/sph/Grid.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/sph/Kernels.inl
+++ b/engine/src/cuda/fragments/sph/Kernels.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/sph/Kernels.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/system/Buffer.inl
+++ b/engine/src/cuda/fragments/system/Buffer.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/system/Buffer.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/system/Core.inl
+++ b/engine/src/cuda/fragments/system/Core.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/system/Core.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/system/Prelude.inl
+++ b/engine/src/cuda/fragments/system/Prelude.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/system/Prelude.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/system/State.inl
+++ b/engine/src/cuda/fragments/system/State.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/system/State.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/thermal/EnergyGpu.inl
+++ b/engine/src/cuda/fragments/thermal/EnergyGpu.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/thermal/EnergyGpu.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/thermal/Thermal.inl
+++ b/engine/src/cuda/fragments/thermal/Thermal.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/thermal/Thermal.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/cuda/fragments/treepm/Gpu.inl
+++ b/engine/src/cuda/fragments/treepm/Gpu.inl
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/cuda/fragments/treepm/Gpu.inl
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/graphics/ColorPipeline.cpp
+++ b/engine/src/graphics/ColorPipeline.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/graphics/ColorPipeline.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/graphics/ViewMath.cpp
+++ b/engine/src/graphics/ViewMath.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/graphics/ViewMath.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/physics/ForceLawPolicy.cpp
+++ b/engine/src/physics/ForceLawPolicy.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/physics/ForceLawPolicy.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Physics and CUDA implementation for the deterministic simulation core.
  */

--- a/engine/src/physics/ParticleHotData.cpp
+++ b/engine/src/physics/ParticleHotData.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/physics/ParticleHotData.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Cache-optimized particle data packing helpers for the physics hotpath.
  */

--- a/engine/src/physics/ParticleSystemHost.cpp
+++ b/engine/src/physics/ParticleSystemHost.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/physics/ParticleSystemHost.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief CPU fallback implementation for the particle system.
  */

--- a/engine/src/platform/Errors.cpp
+++ b/engine/src/platform/Errors.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/platform/Errors.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction implementation for portable runtime services.
  */

--- a/engine/src/platform/common/DynamicLibrary.cpp
+++ b/engine/src/platform/common/DynamicLibrary.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/platform/common/DynamicLibrary.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction implementation for portable runtime services.
  */

--- a/engine/src/platform/common/Process.cpp
+++ b/engine/src/platform/common/Process.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/platform/common/Process.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction implementation for portable runtime services.
  */

--- a/engine/src/platform/common/ProcessImpl.cpp
+++ b/engine/src/platform/common/ProcessImpl.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/platform/common/ProcessImpl.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction implementation for portable runtime services.
  */

--- a/engine/src/platform/common/Socket.cpp
+++ b/engine/src/platform/common/Socket.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/platform/common/Socket.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction implementation for portable runtime services.
  */

--- a/engine/src/platform/posix/DynamicLibrary.cpp
+++ b/engine/src/platform/posix/DynamicLibrary.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/platform/posix/DynamicLibrary.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction implementation for portable runtime services.
  */

--- a/engine/src/platform/posix/Paths.cpp
+++ b/engine/src/platform/posix/Paths.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/platform/posix/Paths.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction implementation for portable runtime services.
  */

--- a/engine/src/platform/posix/Process.cpp
+++ b/engine/src/platform/posix/Process.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/platform/posix/Process.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction implementation for portable runtime services.
  */

--- a/engine/src/platform/win/DynamicLibrary.cpp
+++ b/engine/src/platform/win/DynamicLibrary.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/platform/win/DynamicLibrary.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction implementation for portable runtime services.
  */

--- a/engine/src/platform/win/Paths.cpp
+++ b/engine/src/platform/win/Paths.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/platform/win/Paths.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction implementation for portable runtime services.
  */

--- a/engine/src/platform/win/Process.cpp
+++ b/engine/src/platform/win/Process.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/platform/win/Process.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction implementation for portable runtime services.
  */

--- a/engine/src/platform/win/Socket.cpp
+++ b/engine/src/platform/win/Socket.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/platform/win/Socket.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Platform abstraction implementation for portable runtime services.
  */

--- a/engine/src/server/SimulationInitConfig.cpp
+++ b/engine/src/server/SimulationInitConfig.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/SimulationInitConfig.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/Internal.hpp
+++ b/engine/src/server/simulation/Internal.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/Internal.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/core/FormatAndTheta.cpp
+++ b/engine/src/server/simulation/core/FormatAndTheta.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/core/FormatAndTheta.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/core/Helpers.cpp
+++ b/engine/src/server/simulation/core/Helpers.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/core/Helpers.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/export/Stats.cpp
+++ b/engine/src/server/simulation/export/Stats.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/export/Stats.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/lifecycle/Controls.cpp
+++ b/engine/src/server/simulation/lifecycle/Controls.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/lifecycle/Controls.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/lifecycle/Loop.cpp
+++ b/engine/src/server/simulation/lifecycle/Loop.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/lifecycle/Loop.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/lifecycle/Rebuild.cpp
+++ b/engine/src/server/simulation/lifecycle/Rebuild.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/lifecycle/Rebuild.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/parsing/BinXyz.cpp
+++ b/engine/src/server/simulation/parsing/BinXyz.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/parsing/BinXyz.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/parsing/Vtk.cpp
+++ b/engine/src/server/simulation/parsing/Vtk.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/parsing/Vtk.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/persistence/Checkpoint.cpp
+++ b/engine/src/server/simulation/persistence/Checkpoint.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/persistence/Checkpoint.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/persistence/IO.cpp
+++ b/engine/src/server/simulation/persistence/IO.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/persistence/IO.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/persistence/LoadAndCheckpoint.cpp
+++ b/engine/src/server/simulation/persistence/LoadAndCheckpoint.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/persistence/LoadAndCheckpoint.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/runtime/SettersAndExport.cpp
+++ b/engine/src/server/simulation/runtime/SettersAndExport.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/runtime/SettersAndExport.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/state/Generation.cpp
+++ b/engine/src/server/simulation/state/Generation.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/state/Generation.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/state/InitializationHelper.hpp
+++ b/engine/src/server/simulation/state/InitializationHelper.hpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/state/InitializationHelper.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Helper utilities for deterministic parallel particle generation.
  */

--- a/engine/src/server/simulation/telemetry/PendingOps.cpp
+++ b/engine/src/server/simulation/telemetry/PendingOps.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/telemetry/PendingOps.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/engine/src/server/simulation/telemetry/SnapshotAndEnergy.cpp
+++ b/engine/src/server/simulation/telemetry/SnapshotAndEnergy.cpp
@@ -1,6 +1,6 @@
 /*
  * @file engine/src/server/simulation/telemetry/SnapshotAndEnergy.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Source artifact for the BLITZAR simulation project.
  */

--- a/make/check.mk
+++ b/make/check.mk
@@ -1,5 +1,5 @@
 # @file make/check.mk
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Makefile fragments for local quality and runtime workflows.
 

--- a/make/runtime.mk
+++ b/make/runtime.mk
@@ -1,5 +1,5 @@
 # @file make/runtime.mk
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Makefile fragments for local quality and runtime workflows.
 

--- a/modules/cli/Commands.cpp
+++ b/modules/cli/Commands.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/cli/Commands.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Command-line client module for runtime control workflows.
  */

--- a/modules/cli/Commands.hpp
+++ b/modules/cli/Commands.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/cli/Commands.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Command-line client module for runtime control workflows.
  */

--- a/modules/cli/Lifecycle.cpp
+++ b/modules/cli/Lifecycle.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/cli/Lifecycle.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Command-line client module for runtime control workflows.
  */

--- a/modules/cli/Lifecycle.hpp
+++ b/modules/cli/Lifecycle.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/cli/Lifecycle.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Command-line client module for runtime control workflows.
  */

--- a/modules/cli/Module.cpp
+++ b/modules/cli/Module.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/cli/Module.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Command-line client module for runtime control workflows.
  */

--- a/modules/cli/ServerOps.cpp
+++ b/modules/cli/ServerOps.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/cli/ServerOps.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Command-line client module for runtime control workflows.
  */

--- a/modules/cli/ServerOps.hpp
+++ b/modules/cli/ServerOps.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/cli/ServerOps.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Command-line client module for runtime control workflows.
  */

--- a/modules/cli/State.cpp
+++ b/modules/cli/State.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/cli/State.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Command-line client module for runtime control workflows.
  */

--- a/modules/cli/State.hpp
+++ b/modules/cli/State.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/cli/State.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Command-line client module for runtime control workflows.
  */

--- a/modules/cli/Text.cpp
+++ b/modules/cli/Text.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/cli/Text.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Command-line client module for runtime control workflows.
  */

--- a/modules/cli/Text.hpp
+++ b/modules/cli/Text.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/cli/Text.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Command-line client module for runtime control workflows.
  */

--- a/modules/echo/Module.cpp
+++ b/modules/echo/Module.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/echo/Module.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Echo module used to validate client module loading behavior.
  */

--- a/modules/proxy/Module.cpp
+++ b/modules/proxy/Module.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/proxy/Module.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Proxy module used to validate runtime forwarding behavior.
  */

--- a/modules/proxy/Support.cpp
+++ b/modules/proxy/Support.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/proxy/Support.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Internal support helpers for the GUI proxy client module.
  */

--- a/modules/proxy/Support.hpp
+++ b/modules/proxy/Support.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/proxy/Support.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Internal support helpers for the GUI proxy client module.
  */

--- a/modules/qt/Module.cpp
+++ b/modules/qt/Module.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/Module.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/support/geometry/ViewMath.cpp
+++ b/modules/qt/src/support/geometry/ViewMath.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/support/geometry/ViewMath.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/support/geometry/ViewMath.hpp
+++ b/modules/qt/src/support/geometry/ViewMath.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/support/geometry/ViewMath.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/support/performance/Throughput.cpp
+++ b/modules/qt/src/support/performance/Throughput.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/support/performance/Throughput.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/support/performance/Throughput.hpp
+++ b/modules/qt/src/support/performance/Throughput.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/support/performance/Throughput.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/support/storage/LayoutStore.cpp
+++ b/modules/qt/src/support/storage/LayoutStore.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/support/storage/LayoutStore.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/support/storage/LayoutStore.hpp
+++ b/modules/qt/src/support/storage/LayoutStore.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/support/storage/LayoutStore.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/support/theme/Theme.cpp
+++ b/modules/qt/src/support/theme/Theme.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/support/theme/Theme.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/support/theme/Theme.hpp
+++ b/modules/qt/src/support/theme/Theme.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/support/theme/Theme.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/support/types/Enums.cpp
+++ b/modules/qt/src/support/types/Enums.cpp
@@ -1,6 +1,6 @@
 /**
  * @file UiEnums.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/graphs/Graph.cpp
+++ b/modules/qt/src/widgets/graphs/Graph.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/graphs/Graph.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/graphs/Graph.hpp
+++ b/modules/qt/src/widgets/graphs/Graph.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/graphs/Graph.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/graphs/Paint.cpp
+++ b/modules/qt/src/widgets/graphs/Paint.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/graphs/Paint.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/graphs/Paint.hpp
+++ b/modules/qt/src/widgets/graphs/Paint.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/graphs/Paint.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/overlays/Octree.cpp
+++ b/modules/qt/src/widgets/overlays/Octree.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/overlays/Octree.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/overlays/Octree.hpp
+++ b/modules/qt/src/widgets/overlays/Octree.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/overlays/Octree.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/overlays/Painter.cpp
+++ b/modules/qt/src/widgets/overlays/Painter.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/overlays/Painter.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/overlays/Painter.hpp
+++ b/modules/qt/src/widgets/overlays/Painter.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/overlays/Painter.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/viewport/Color.cpp
+++ b/modules/qt/src/widgets/viewport/Color.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/viewport/Color.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/viewport/Color.hpp
+++ b/modules/qt/src/widgets/viewport/Color.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/viewport/Color.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/viewport/MultiView.cpp
+++ b/modules/qt/src/widgets/viewport/MultiView.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/viewport/MultiView.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/viewport/MultiView.hpp
+++ b/modules/qt/src/widgets/viewport/MultiView.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/viewport/MultiView.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/viewport/Particle.cpp
+++ b/modules/qt/src/widgets/viewport/Particle.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/viewport/Particle.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/widgets/viewport/Particle.hpp
+++ b/modules/qt/src/widgets/viewport/Particle.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/widgets/viewport/Particle.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/window/actions/FileActions.cpp
+++ b/modules/qt/src/window/actions/FileActions.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/actions/FileActions.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/window/config/WindowConfig.cpp
+++ b/modules/qt/src/window/config/WindowConfig.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/config/WindowConfig.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/window/control/Controller.cpp
+++ b/modules/qt/src/window/control/Controller.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/control/Controller.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/window/control/Controller.hpp
+++ b/modules/qt/src/window/control/Controller.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/control/Controller.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/window/control/Controls.cpp
+++ b/modules/qt/src/window/control/Controls.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/control/Controls.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/window/core/Widgets.cpp
+++ b/modules/qt/src/window/core/Widgets.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/core/Widgets.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt window widget ownership group construction.
  */

--- a/modules/qt/src/window/core/Widgets.hpp
+++ b/modules/qt/src/window/core/Widgets.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/core/Widgets.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt window widget ownership groups.
  */

--- a/modules/qt/src/window/core/Window.cpp
+++ b/modules/qt/src/window/core/Window.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/core/Window.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/window/core/Window.hpp
+++ b/modules/qt/src/window/core/Window.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/core/Window.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/window/layout/Layout.cpp
+++ b/modules/qt/src/window/layout/Layout.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/layout/Layout.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/window/presentation/Presenter.cpp
+++ b/modules/qt/src/window/presentation/Presenter.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/presentation/Presenter.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/window/presentation/Presenter.hpp
+++ b/modules/qt/src/window/presentation/Presenter.hpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/presentation/Presenter.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/window/presentation/Telemetry.cpp
+++ b/modules/qt/src/window/presentation/Telemetry.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/presentation/Telemetry.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/window/workspace/Persistence.cpp
+++ b/modules/qt/src/window/workspace/Persistence.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/workspace/Persistence.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/modules/qt/src/window/workspace/Shell.cpp
+++ b/modules/qt/src/window/workspace/Shell.cpp
@@ -1,6 +1,6 @@
 /*
  * @file modules/qt/src/window/workspace/Shell.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Qt desktop user interface module for simulation control and visualization.
  */

--- a/python_tools/__init__.py
+++ b/python_tools/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 # @file python_tools/__init__.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.

--- a/python_tools/ci/__init__.py
+++ b/python_tools/ci/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/__init__.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.

--- a/python_tools/ci/changelog.py
+++ b/python_tools/ci/changelog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/changelog.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/clang_tidy.py
+++ b/python_tools/ci/clang_tidy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/clang_tidy.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/clang_tidy_file_executor.py
+++ b/python_tools/ci/clang_tidy_file_executor.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/clang_tidy_file_executor.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/coverage_dashboard.py
+++ b/python_tools/ci/coverage_dashboard.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/coverage_dashboard.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/fmea_status.py
+++ b/python_tools/ci/fmea_status.py
@@ -1,5 +1,5 @@
 # @file python_tools/ci/fmea_status.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/gpu_runner_bootstrap.py
+++ b/python_tools/ci/gpu_runner_bootstrap.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/gpu_runner_bootstrap.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/gpu_runner_inventory.py
+++ b/python_tools/ci/gpu_runner_inventory.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/gpu_runner_inventory.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/numerical_validation.py
+++ b/python_tools/ci/numerical_validation.py
@@ -1,5 +1,5 @@
 # @file python_tools/ci/numerical_validation.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/performance_benchmark.py
+++ b/python_tools/ci/performance_benchmark.py
@@ -1,5 +1,5 @@
 # @file python_tools/ci/performance_benchmark.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/python_quality_gate.py
+++ b/python_tools/ci/python_quality_gate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/python_quality_gate.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/release_bundle.py
+++ b/python_tools/ci/release_bundle.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/release_bundle.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/release_evidence_pack.py
+++ b/python_tools/ci/release_evidence_pack.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/release_evidence_pack.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/release_quality_index.py
+++ b/python_tools/ci/release_quality_index.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/release_quality_index.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/release_sbom.py
+++ b/python_tools/ci/release_sbom.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/release_sbom.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/release_source.py
+++ b/python_tools/ci/release_source.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/release_source.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/release_support.py
+++ b/python_tools/ci/release_support.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/release_support.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/tool_manifest.py
+++ b/python_tools/ci/tool_manifest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/tool_manifest.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/ci/windows_installer.py
+++ b/python_tools/ci/windows_installer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/ci/windows_installer.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/core/__init__.py
+++ b/python_tools/core/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 # @file python_tools/core/__init__.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.

--- a/python_tools/core/base_check.py
+++ b/python_tools/core/base_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/core/base_check.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/core/io.py
+++ b/python_tools/core/io.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/core/io.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/core/models.py
+++ b/python_tools/core/models.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/core/models.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/core/reporting.py
+++ b/python_tools/core/reporting.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/core/reporting.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/core/runner.py
+++ b/python_tools/core/runner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/core/runner.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/deviation_register.py
+++ b/python_tools/policies/deviation_register.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/deviation_register.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/fmea_action_register.py
+++ b/python_tools/policies/fmea_action_register.py
@@ -1,5 +1,5 @@
 # @file python_tools/policies/fmea_action_register.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/header_definition_policy.py
+++ b/python_tools/policies/header_definition_policy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/header_definition_policy.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/ini_check.py
+++ b/python_tools/policies/ini_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/ini_check.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/ivv_gate.py
+++ b/python_tools/policies/ivv_gate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/ivv_gate.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/launcher_check.py
+++ b/python_tools/policies/launcher_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/launcher_check.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/main_delivery_policy.py
+++ b/python_tools/policies/main_delivery_policy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/main_delivery_policy.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/mirror_check.py
+++ b/python_tools/policies/mirror_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/mirror_check.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/no_legacy_check.py
+++ b/python_tools/policies/no_legacy_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/no_legacy_check.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/pr_policy.py
+++ b/python_tools/policies/pr_policy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/pr_policy.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/quality_baseline.py
+++ b/python_tools/policies/quality_baseline.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/quality_baseline.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/quality_manifest.py
+++ b/python_tools/policies/quality_manifest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/quality_manifest.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/repo_policy.py
+++ b/python_tools/policies/repo_policy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/repo_policy.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/repo_policy_function_metrics.py
+++ b/python_tools/policies/repo_policy_function_metrics.py
@@ -1,5 +1,5 @@
 # @file python_tools/policies/repo_policy_function_metrics.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/repo_policy_workflows.py
+++ b/python_tools/policies/repo_policy_workflows.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/repo_policy_workflows.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/test_catalog.py
+++ b/python_tools/policies/test_catalog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/test_catalog.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/python_tools/policies/traceability_gate.py
+++ b/python_tools/policies/traceability_gate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file python_tools/policies/traceability_gate.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Python quality and automation support for BLITZAR governance.
 

--- a/runtime/include/client/common/ClientCommon.hpp
+++ b/runtime/include/client/common/ClientCommon.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/client/common/ClientCommon.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/client/diagnostics/ErrorBuffer.hpp
+++ b/runtime/include/client/diagnostics/ErrorBuffer.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/client/diagnostics/ErrorBuffer.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/client/module/Api.hpp
+++ b/runtime/include/client/module/Api.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/client/module/Api.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/client/module/Boundary.hpp
+++ b/runtime/include/client/module/Boundary.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/client/module/Boundary.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/client/module/Handle.hpp
+++ b/runtime/include/client/module/Handle.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/client/module/Handle.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/client/module/Hash.hpp
+++ b/runtime/include/client/module/Hash.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/client/module/Hash.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/client/module/Manifest.hpp
+++ b/runtime/include/client/module/Manifest.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/client/module/Manifest.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/client/runtime/Bridge.hpp
+++ b/runtime/include/client/runtime/Bridge.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/client/runtime/Bridge.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/client/runtime/BridgeState.hpp
+++ b/runtime/include/client/runtime/BridgeState.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/client/runtime/BridgeState.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/client/runtime/Interface.hpp
+++ b/runtime/include/client/runtime/Interface.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/client/runtime/Interface.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/client/runtime/Runtime.hpp
+++ b/runtime/include/client/runtime/Runtime.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/client/runtime/Runtime.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/command/catalog/Catalog.hpp
+++ b/runtime/include/command/catalog/Catalog.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/command/catalog/Catalog.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/command/core/Context.hpp
+++ b/runtime/include/command/core/Context.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/command/core/Context.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/command/core/Types.hpp
+++ b/runtime/include/command/core/Types.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/command/core/Types.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/command/execution/BatchRunner.hpp
+++ b/runtime/include/command/execution/BatchRunner.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/command/execution/BatchRunner.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/command/execution/Executor.hpp
+++ b/runtime/include/command/execution/Executor.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/command/execution/Executor.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/command/parsing/Parser.hpp
+++ b/runtime/include/command/parsing/Parser.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/command/parsing/Parser.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/command/transport/Transport.hpp
+++ b/runtime/include/command/transport/Transport.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/command/transport/Transport.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/ffi/bridge/Api.hpp
+++ b/runtime/include/ffi/bridge/Api.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/ffi/bridge/Api.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/ffi/core/Api.hpp
+++ b/runtime/include/ffi/core/Api.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/ffi/core/Api.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/protocol/Protocol.hpp
+++ b/runtime/include/protocol/Protocol.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/protocol/Protocol.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/protocol/client/Client.hpp
+++ b/runtime/include/protocol/client/Client.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/protocol/client/Client.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/protocol/codec/JsonCodec.hpp
+++ b/runtime/include/protocol/codec/JsonCodec.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/protocol/codec/JsonCodec.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/include/server/core/Daemon.hpp
+++ b/runtime/include/server/core/Daemon.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/server/core/Daemon.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/common/ClientCommon.cpp
+++ b/runtime/src/client/common/ClientCommon.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/client/common/ClientCommon.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/common/Common.cpp
+++ b/runtime/src/client/common/Common.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/client/common/Common.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/diagnostics/ErrorBuffer.cpp
+++ b/runtime/src/client/diagnostics/ErrorBuffer.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/client/diagnostics/ErrorBuffer.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/module/Api.cpp
+++ b/runtime/src/client/module/Api.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/client/module/Api.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/module/Boundary.cpp
+++ b/runtime/src/client/module/Boundary.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/client/module/Boundary.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/module/Handle.cpp
+++ b/runtime/src/client/module/Handle.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/client/module/Handle.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/module/Hash.cpp
+++ b/runtime/src/client/module/Hash.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/client/module/Hash.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/module/Internal.hpp
+++ b/runtime/src/client/module/Internal.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/client/module/Internal.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/module/Load.cpp
+++ b/runtime/src/client/module/Load.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/client/module/Load.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/module/Load.hpp
+++ b/runtime/src/client/module/Load.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/include/client/module/Load.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/module/Manifest.cpp
+++ b/runtime/src/client/module/Manifest.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/client/module/Manifest.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/runtime/Bridge.cpp
+++ b/runtime/src/client/runtime/Bridge.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/client/runtime/Bridge.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/runtime/BridgeState.cpp
+++ b/runtime/src/client/runtime/BridgeState.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/client/runtime/BridgeState.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/client/runtime/Runtime.cpp
+++ b/runtime/src/client/runtime/Runtime.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/client/runtime/Runtime.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/command/catalog/Catalog.cpp
+++ b/runtime/src/command/catalog/Catalog.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/command/catalog/Catalog.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/command/execution/BatchRunner.cpp
+++ b/runtime/src/command/execution/BatchRunner.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/command/execution/BatchRunner.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/command/execution/Executor.cpp
+++ b/runtime/src/command/execution/Executor.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/command/execution/Executor.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/command/parsing/Parser.cpp
+++ b/runtime/src/command/parsing/Parser.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/command/parsing/Parser.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/command/transport/Transport.cpp
+++ b/runtime/src/command/transport/Transport.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/command/transport/Transport.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/ffi/bridge/Api.cpp
+++ b/runtime/src/ffi/bridge/Api.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/ffi/bridge/Api.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief C++ fallback implementation of the client runtime bridge ABI.
  */

--- a/runtime/src/ffi/core/Api.cpp
+++ b/runtime/src/ffi/core/Api.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/ffi/core/Api.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/ffi/core/Core.cpp
+++ b/runtime/src/ffi/core/Core.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/ffi/core/Core.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/ffi/core/Internal.hpp
+++ b/runtime/src/ffi/core/Internal.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/ffi/core/Internal.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/ffi/core/Ops.cpp
+++ b/runtime/src/ffi/core/Ops.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/ffi/core/Ops.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/protocol/Protocol.cpp
+++ b/runtime/src/protocol/Protocol.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/protocol/Protocol.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/protocol/client/Client.cpp
+++ b/runtime/src/protocol/client/Client.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/protocol/client/Client.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/protocol/codec/JsonCodec.cpp
+++ b/runtime/src/protocol/codec/JsonCodec.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/protocol/codec/JsonCodec.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/protocol/codec/parser/Number.cpp
+++ b/runtime/src/protocol/codec/parser/Number.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/protocol/codec/parser/Number.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/protocol/codec/parser/Number.hpp
+++ b/runtime/src/protocol/codec/parser/Number.hpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/protocol/codec/parser/Number.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime public interfaces for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/protocol/codec/parser/Parser.cpp
+++ b/runtime/src/protocol/codec/parser/Parser.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/protocol/codec/parser/Parser.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/protocol/codec/parser/Snapshot.cpp
+++ b/runtime/src/protocol/codec/parser/Snapshot.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/protocol/codec/parser/Snapshot.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/protocol/codec/parser/Status.cpp
+++ b/runtime/src/protocol/codec/parser/Status.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/protocol/codec/parser/Status.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/runtime/src/server/core/Daemon.cpp
+++ b/runtime/src/server/core/Daemon.cpp
@@ -1,6 +1,6 @@
 /*
  * @file runtime/src/server/core/Daemon.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Runtime implementation for protocol, command, client, and FFI boundaries.
  */

--- a/rust/blitzar-protocol/src/codec.rs
+++ b/rust/blitzar-protocol/src/codec.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-protocol/src/codec.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-protocol/src/framing.rs
+++ b/rust/blitzar-protocol/src/framing.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-protocol/src/framing.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-protocol/src/lib.rs
+++ b/rust/blitzar-protocol/src/lib.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-protocol/src/lib.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-protocol/src/schema.rs
+++ b/rust/blitzar-protocol/src/schema.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-protocol/src/schema.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-protocol/src/v1/command.rs
+++ b/rust/blitzar-protocol/src/v1/command.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-protocol/src/v1/command.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-protocol/src/v1/envelope.rs
+++ b/rust/blitzar-protocol/src/v1/envelope.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-protocol/src/v1/envelope.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-protocol/src/v1/mod.rs
+++ b/rust/blitzar-protocol/src/v1/mod.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-protocol/src/v1/mod.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-protocol/src/v1/snapshot.rs
+++ b/rust/blitzar-protocol/src/v1/snapshot.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-protocol/src/v1/snapshot.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-protocol/src/v1/status.rs
+++ b/rust/blitzar-protocol/src/v1/status.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-protocol/src/v1/status.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-protocol/src/version.rs
+++ b/rust/blitzar-protocol/src/version.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-protocol/src/version.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-protocol/tests/protocol.rs
+++ b/rust/blitzar-protocol/tests/protocol.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-protocol/tests/protocol.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-runtime/src/bridge_state.rs
+++ b/rust/blitzar-runtime/src/bridge_state.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-runtime/src/bridge_state.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-runtime/src/ffi.rs
+++ b/rust/blitzar-runtime/src/ffi.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-runtime/src/ffi.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-runtime/src/lib.rs
+++ b/rust/blitzar-runtime/src/lib.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-runtime/src/lib.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-runtime/tests/bridge_state.rs
+++ b/rust/blitzar-runtime/tests/bridge_state.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-runtime/tests/bridge_state.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-web-gateway/src/api.rs
+++ b/rust/blitzar-web-gateway/src/api.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-web-gateway/src/api.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-web-gateway/src/args.rs
+++ b/rust/blitzar-web-gateway/src/args.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-web-gateway/src/args.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-web-gateway/src/backend.rs
+++ b/rust/blitzar-web-gateway/src/backend.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-web-gateway/src/backend.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-web-gateway/src/error.rs
+++ b/rust/blitzar-web-gateway/src/error.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-web-gateway/src/error.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-web-gateway/src/events.rs
+++ b/rust/blitzar-web-gateway/src/events.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-web-gateway/src/events.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-web-gateway/src/lib.rs
+++ b/rust/blitzar-web-gateway/src/lib.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-web-gateway/src/lib.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-web-gateway/src/main.rs
+++ b/rust/blitzar-web-gateway/src/main.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-web-gateway/src/main.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-web-gateway/src/ws.rs
+++ b/rust/blitzar-web-gateway/src/ws.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-web-gateway/src/ws.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-web-gateway/tests/args.rs
+++ b/rust/blitzar-web-gateway/tests/args.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-web-gateway/tests/args.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-web-gateway/tests/events.rs
+++ b/rust/blitzar-web-gateway/tests/events.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-web-gateway/tests/events.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/rust/blitzar-web-gateway/tests/http.rs
+++ b/rust/blitzar-web-gateway/tests/http.rs
@@ -1,6 +1,6 @@
 /*
  * @file rust/blitzar-web-gateway/tests/http.rs
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Rust protocol and gateway components for BLITZAR runtime integration.
  */

--- a/scripts/ci/coverage/build_pr_delta_report.py
+++ b/scripts/ci/coverage/build_pr_delta_report.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/coverage/build_pr_delta_report.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/gpu/bootstrap_windows_runner.py
+++ b/scripts/ci/gpu/bootstrap_windows_runner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/gpu/bootstrap_windows_runner.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/gpu/runner_health.py
+++ b/scripts/ci/gpu/runner_health.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/gpu/runner_health.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/nightly/build_dashboard.py
+++ b/scripts/ci/nightly/build_dashboard.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/nightly/build_dashboard.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/nightly/generate_coverage.sh
+++ b/scripts/ci/nightly/generate_coverage.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # @file scripts/ci/nightly/generate_coverage.sh
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/nightly/package_fmea_status.py
+++ b/scripts/ci/nightly/package_fmea_status.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/nightly/package_fmea_status.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/nightly/package_numerical_validation.py
+++ b/scripts/ci/nightly/package_numerical_validation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/nightly/package_numerical_validation.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/nightly/package_performance_benchmark.py
+++ b/scripts/ci/nightly/package_performance_benchmark.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/nightly/package_performance_benchmark.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/nightly/publish_coverage_branch.sh
+++ b/scripts/ci/nightly/publish_coverage_branch.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # @file scripts/ci/nightly/publish_coverage_branch.sh
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/release/generate_changelog.py
+++ b/scripts/ci/release/generate_changelog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/release/generate_changelog.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/release/package_bundle.py
+++ b/scripts/ci/release/package_bundle.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/release/package_bundle.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/release/package_evidence.py
+++ b/scripts/ci/release/package_evidence.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/release/package_evidence.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/release/package_quality_index.py
+++ b/scripts/ci/release/package_quality_index.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/release/package_quality_index.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/release/package_sbom.py
+++ b/scripts/ci/release/package_sbom.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/release/package_sbom.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/release/package_source.py
+++ b/scripts/ci/release/package_source.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/release/package_source.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/release/package_tool_manifest.py
+++ b/scripts/ci/release/package_tool_manifest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/release/package_tool_manifest.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/release/publish_release.py
+++ b/scripts/ci/release/publish_release.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/release/publish_release.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/release/smoke_portable_bundle.py
+++ b/scripts/ci/release/smoke_portable_bundle.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/release/smoke_portable_bundle.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/ci/release/smoke_windows_installer.py
+++ b/scripts/ci/release/smoke_windows_installer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file scripts/ci/release/smoke_windows_installer.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/deps_graphics.cmake
+++ b/scripts/deps_graphics.cmake
@@ -1,5 +1,5 @@
 # @file scripts/deps_graphics.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/doctor.cmake
+++ b/scripts/doctor.cmake
@@ -1,5 +1,5 @@
 # @file scripts/doctor.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/generate_client_module_manifest.cmake
+++ b/scripts/generate_client_module_manifest.cmake
@@ -1,5 +1,5 @@
 # @file scripts/generate_client_module_manifest.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/rm_paths.cmake
+++ b/scripts/rm_paths.cmake
@@ -1,5 +1,5 @@
 # @file scripts/rm_paths.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/scripts/run_qt.sh
+++ b/scripts/run_qt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # @file scripts/run_qt.sh
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Build, release, and CI helper automation for BLITZAR workflows.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # @file tests/CMakeLists.txt
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 # @file tests/__init__.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.

--- a/tests/checks/__init__.py
+++ b/tests/checks/__init__.py
@@ -1,5 +1,5 @@
 # @file tests/checks/__init__.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/catalog.py
+++ b/tests/checks/catalog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file tests/checks/catalog.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/check.py
+++ b/tests/checks/check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file tests/checks/check.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/run.py
+++ b/tests/checks/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file tests/checks/run.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/__init__.py
+++ b/tests/checks/suites/__init__.py
@@ -1,5 +1,5 @@
 # @file tests/checks/suites/__init__.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/conftest.py
+++ b/tests/checks/suites/conftest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file tests/checks/suites/conftest.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/core/test_clang_tidy.py
+++ b/tests/checks/suites/core/test_clang_tidy.py
@@ -1,5 +1,5 @@
 # @file tests/checks/suites/core/test_clang_tidy.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/core/test_coverage_dashboard.py
+++ b/tests/checks/suites/core/test_coverage_dashboard.py
@@ -1,5 +1,5 @@
 # @file tests/checks/suites/core/test_coverage_dashboard.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/core/test_coverage_publication.py
+++ b/tests/checks/suites/core/test_coverage_publication.py
@@ -1,5 +1,5 @@
 # @file tests/checks/suites/core/test_coverage_publication.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 
@@ -8,15 +8,15 @@ from __future__ import annotations
 from pathlib import Path
 
 
-# @brief Documents the test readme avoids owner specific coverage urls operation contract.
+# @brief Documents the test readme uses coverage data branch for badges and widget operation contract.
 # @param None This contract does not take explicit parameters.
 # @return Value produced by this contract when applicable.
 # @note Keep side effects explicit and preserve deterministic behavior where callers depend on it.
-def test_readme_avoids_owner_specific_coverage_urls() -> None:
+def test_readme_uses_coverage_data_branch_for_badges_and_widget() -> None:
     readme = Path("README.md").read_text(encoding="utf-8")
-    assert "raw.githubusercontent.com" not in readme
-    assert "github.com/" not in readme
-    assert ".github.io/BLITZAR/coverage/" not in readme
+    assert "raw.githubusercontent.com/Luis1454/BLITZAR/coverage-data/coverage/widget.svg" in readme
+    assert "raw.githubusercontent.com%2FLuis1454%2FBLITZAR%2Fcoverage-data%2Fcoverage%2Flines.json" in readme
+    assert "luis1454.github.io/BLITZAR/coverage/" not in readme
 
 
 # @brief Documents the test nightly workflow publishes coverage data branch operation contract.

--- a/tests/checks/suites/core/test_framework_core.py
+++ b/tests/checks/suites/core/test_framework_core.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file tests/checks/suites/core/test_framework_core.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/core/test_gpu_runner_ops.py
+++ b/tests/checks/suites/core/test_gpu_runner_ops.py
@@ -1,5 +1,5 @@
 # @file tests/checks/suites/core/test_gpu_runner_ops.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/core/test_release_sbom.py
+++ b/tests/checks/suites/core/test_release_sbom.py
@@ -1,5 +1,5 @@
 # @file tests/checks/suites/core/test_release_sbom.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/policy/test_deviation_fmea.py
+++ b/tests/checks/suites/policy/test_deviation_fmea.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file tests/checks/suites/policy/test_deviation_fmea.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/policy/test_quality_structure.py
+++ b/tests/checks/suites/policy/test_quality_structure.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file tests/checks/suites/policy/test_quality_structure.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/policy/test_repo_policy.py
+++ b/tests/checks/suites/policy/test_repo_policy.py
@@ -1,5 +1,5 @@
 # @file tests/checks/suites/policy/test_repo_policy.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/policy/test_repo_policy_decomposition.py
+++ b/tests/checks/suites/policy/test_repo_policy_decomposition.py
@@ -1,5 +1,5 @@
 # @file tests/checks/suites/policy/test_repo_policy_decomposition.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/policy/test_repo_policy_headers.py
+++ b/tests/checks/suites/policy/test_repo_policy_headers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file tests/checks/suites/policy/test_repo_policy_headers.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/policy/test_repo_policy_power_of_10.py
+++ b/tests/checks/suites/policy/test_repo_policy_power_of_10.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file tests/checks/suites/policy/test_repo_policy_power_of_10.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/policy/test_repo_policy_workflows.py
+++ b/tests/checks/suites/policy/test_repo_policy_workflows.py
@@ -1,5 +1,5 @@
 # @file tests/checks/suites/policy/test_repo_policy_workflows.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/policy/test_review_gates.py
+++ b/tests/checks/suites/policy/test_review_gates.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file tests/checks/suites/policy/test_review_gates.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/policy/test_review_gates_solo.py
+++ b/tests/checks/suites/policy/test_review_gates_solo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file tests/checks/suites/policy/test_review_gates_solo.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/release/test_performance_benchmark.py
+++ b/tests/checks/suites/release/test_performance_benchmark.py
@@ -1,5 +1,5 @@
 # @file tests/checks/suites/release/test_performance_benchmark.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/release/test_release_desktop_installer.py
+++ b/tests/checks/suites/release/test_release_desktop_installer.py
@@ -1,5 +1,5 @@
 # @file tests/checks/suites/release/test_release_desktop_installer.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/release/test_release_evidence.py
+++ b/tests/checks/suites/release/test_release_evidence.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file tests/checks/suites/release/test_release_evidence.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/release/test_release_outputs.py
+++ b/tests/checks/suites/release/test_release_outputs.py
@@ -1,5 +1,5 @@
 # @file tests/checks/suites/release/test_release_outputs.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/support/path_specs.py
+++ b/tests/checks/suites/support/path_specs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # @file tests/checks/suites/support/path_specs.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/checks/suites/test_changelog.py
+++ b/tests/checks/suites/test_changelog.py
@@ -1,5 +1,5 @@
 # @file tests/checks/suites/test_changelog.py
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/cmake/setup.cmake
+++ b/tests/cmake/setup.cmake
@@ -1,5 +1,5 @@
 # @file tests/cmake/setup.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/cmake/targets.cmake
+++ b/tests/cmake/targets.cmake
@@ -1,5 +1,5 @@
 # @file tests/cmake/targets.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/cmake/targets_gtests.cmake
+++ b/tests/cmake/targets_gtests.cmake
@@ -1,5 +1,5 @@
 # @file tests/cmake/targets_gtests.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/cmake/targets_repo_checks.cmake
+++ b/tests/cmake/targets_repo_checks.cmake
@@ -1,5 +1,5 @@
 # @file tests/cmake/targets_repo_checks.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/cmake/windows_paths.cmake
+++ b/tests/cmake/windows_paths.cmake
@@ -1,5 +1,5 @@
 # @file tests/cmake/windows_paths.cmake
-# @author BLITZAR Contributors
+# @author Luis1454
 # @project BLITZAR
 # @brief Automated verification assets for BLITZAR quality gates.
 

--- a/tests/int/protocol/connect.cpp
+++ b/tests/int/protocol/connect.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/int/protocol/connect.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/int/protocol/control.cpp
+++ b/tests/int/protocol/control.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/int/protocol/control.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/int/protocol/replay.cpp
+++ b/tests/int/protocol/replay.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/int/protocol/replay.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/int/runtime/bridge.cpp
+++ b/tests/int/runtime/bridge.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/int/runtime/bridge.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/int/runtime/runtime.cpp
+++ b/tests/int/runtime/runtime.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/int/runtime/runtime.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/int/runtime/runtime_draw_cap.cpp
+++ b/tests/int/runtime/runtime_draw_cap.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/int/runtime/runtime_draw_cap.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/int/runtime/runtime_reload.cpp
+++ b/tests/int/runtime/runtime_reload.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/int/runtime/runtime_reload.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/int/runtime/runtime_unit_like.cpp
+++ b/tests/int/runtime/runtime_unit_like.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/int/runtime/runtime_unit_like.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/int/ui/qt_window.cpp
+++ b/tests/int/ui/qt_window.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/int/ui/qt_window.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/int/ui/qt_window_visual.cpp
+++ b/tests/int/ui/qt_window_visual.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/int/ui/qt_window_visual.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/int/ui/qt_workspace_controls.cpp
+++ b/tests/int/ui/qt_workspace_controls.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/int/ui/qt_workspace_controls.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/int/ui/qt_workspace_overlay_controls.cpp
+++ b/tests/int/ui/qt_workspace_overlay_controls.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/int/ui/qt_workspace_overlay_controls.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/int/ui/qt_workspace_runtime_controls.cpp
+++ b/tests/int/ui/qt_workspace_runtime_controls.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/int/ui/qt_workspace_runtime_controls.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/client_utils.cpp
+++ b/tests/support/client_utils.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/client_utils.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/client_utils.hpp
+++ b/tests/support/client_utils.hpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/client_utils.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/numerical_validation_tool.cpp
+++ b/tests/support/numerical_validation_tool.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/numerical_validation_tool.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/numerical_validation_tool.hpp
+++ b/tests/support/numerical_validation_tool.hpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/numerical_validation_tool.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/performance_benchmark_tool.cpp
+++ b/tests/support/performance_benchmark_tool.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/performance_benchmark_tool.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/performance_benchmark_tool.hpp
+++ b/tests/support/performance_benchmark_tool.hpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/performance_benchmark_tool.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/physics_scenario.cpp
+++ b/tests/support/physics_scenario.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/physics_scenario.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/physics_scenario.hpp
+++ b/tests/support/physics_scenario.hpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/physics_scenario.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/physics_test_utils.cpp
+++ b/tests/support/physics_test_utils.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/physics_test_utils.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/physics_test_utils.hpp
+++ b/tests/support/physics_test_utils.hpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/physics_test_utils.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/poll_utils.cpp
+++ b/tests/support/poll_utils.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/poll_utils.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/poll_utils.hpp
+++ b/tests/support/poll_utils.hpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/poll_utils.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/qt_test_utils.cpp
+++ b/tests/support/qt_test_utils.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/qt_test_utils.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/qt_test_utils.hpp
+++ b/tests/support/qt_test_utils.hpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/qt_test_utils.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/scoped_env_var.hpp
+++ b/tests/support/scoped_env_var.hpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/scoped_env_var.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/scoped_env_var_posix.cpp
+++ b/tests/support/scoped_env_var_posix.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/scoped_env_var_posix.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/scoped_env_var_win.cpp
+++ b/tests/support/scoped_env_var_win.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/scoped_env_var_win.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/server_harness.cpp
+++ b/tests/support/server_harness.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/server_harness.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/server_harness.hpp
+++ b/tests/support/server_harness.hpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/server_harness.hpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/support/server_harness_runtime.cpp
+++ b/tests/support/server_harness_runtime.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/support/server_harness_runtime.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/tools/numerical_validation_main.cpp
+++ b/tests/tools/numerical_validation_main.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/tools/numerical_validation_main.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/tools/performance_benchmark_main.cpp
+++ b/tests/tools/performance_benchmark_main.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/tools/performance_benchmark_main.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/config/args_cli.cpp
+++ b/tests/unit/config/args_cli.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/config/args_cli.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/config/args_cli_usage.cpp
+++ b/tests/unit/config/args_cli_usage.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/config/args_cli_usage.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/config/args_io.cpp
+++ b/tests/unit/config/args_io.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/config/args_io.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/config/args_io_directive.cpp
+++ b/tests/unit/config/args_io_directive.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/config/args_io_directive.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/config/args_io_validation.cpp
+++ b/tests/unit/config/args_io_validation.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/config/args_io_validation.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/config/args_octree.cpp
+++ b/tests/unit/config/args_octree.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/config/args_octree.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/config/env_utils.cpp
+++ b/tests/unit/config/env_utils.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/config/env_utils.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/config/init_plan_edges.cpp
+++ b/tests/unit/config/init_plan_edges.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/config/init_plan_edges.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/config/scenario_validation.cpp
+++ b/tests/unit/config/scenario_validation.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/config/scenario_validation.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/config/scenario_validation_edges.cpp
+++ b/tests/unit/config/scenario_validation_edges.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/config/scenario_validation_edges.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/config/scenario_validation_init_modes.cpp
+++ b/tests/unit/config/scenario_validation_init_modes.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/config/scenario_validation_init_modes.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/config/simulation_profile.cpp
+++ b/tests/unit/config/simulation_profile.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/config/simulation_profile.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/ffi/core_api.cpp
+++ b/tests/unit/ffi/core_api.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/ffi/core_api.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/ffi/vtk_conformance.cpp
+++ b/tests/unit/ffi/vtk_conformance.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/ffi/vtk_conformance.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/graphics/TST_UNT_GRA_GraphicsTests.cpp
+++ b/tests/unit/graphics/TST_UNT_GRA_GraphicsTests.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/graphics/TST_UNT_GRA_GraphicsTests.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_cli/command_batch_runner.cpp
+++ b/tests/unit/module_cli/command_batch_runner.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_cli/command_batch_runner.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_cli/command_catalog.cpp
+++ b/tests/unit/module_cli/command_catalog.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_cli/command_catalog.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_cli/command_executor.cpp
+++ b/tests/unit/module_cli/command_executor.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_cli/command_executor.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_cli/command_executor_flows.cpp
+++ b/tests/unit/module_cli/command_executor_flows.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_cli/command_executor_flows.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_cli/command_executor_flows_profile_export.cpp
+++ b/tests/unit/module_cli/command_executor_flows_profile_export.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_cli/command_executor_flows_profile_export.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_cli/command_parser.cpp
+++ b/tests/unit/module_cli/command_parser.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_cli/command_parser.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_cli/command_parser_expansion_a.cpp
+++ b/tests/unit/module_cli/command_parser_expansion_a.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_cli/command_parser_expansion_a.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_cli/command_parser_expansion_b.cpp
+++ b/tests/unit/module_cli/command_parser_expansion_b.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_cli/command_parser_expansion_b.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_cli/server_ops_validation.cpp
+++ b/tests/unit/module_cli/server_ops_validation.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_cli/server_ops_validation.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_cli/text_and_commands.cpp
+++ b/tests/unit/module_cli/text_and_commands.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_cli/text_and_commands.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_client/cli_args_text.cpp
+++ b/tests/unit/module_client/cli_args_text.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_client/cli_args_text.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_client/client_common.cpp
+++ b/tests/unit/module_client/client_common.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_client/client_common.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_client/client_module_boundary.cpp
+++ b/tests/unit/module_client/client_module_boundary.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_client/client_module_boundary.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/module_client/platform_adapters.cpp
+++ b/tests/unit/module_client/platform_adapters.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/module_client/platform_adapters.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/physics/TST_PHY_ProfileTests.cpp
+++ b/tests/unit/physics/TST_PHY_ProfileTests.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/physics/TST_PHY_ProfileTests.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/physics/checkpoint.cpp
+++ b/tests/unit/physics/checkpoint.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/physics/checkpoint.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/physics/export_queue.cpp
+++ b/tests/unit/physics/export_queue.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/physics/export_queue.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/physics/extended_solvers.cpp
+++ b/tests/unit/physics/extended_solvers.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/physics/extended_solvers.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/physics/force_law_policy.cpp
+++ b/tests/unit/physics/force_law_policy.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/physics/force_law_policy.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/physics/multibody.cpp
+++ b/tests/unit/physics/multibody.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/physics/multibody.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/physics/octree_criteria.cpp
+++ b/tests/unit/physics/octree_criteria.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/physics/octree_criteria.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/physics/octree_gpu_stability.cpp
+++ b/tests/unit/physics/octree_gpu_stability.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/physics/octree_gpu_stability.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/physics/orbit.cpp
+++ b/tests/unit/physics/orbit.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/physics/orbit.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/physics/reentrancy.cpp
+++ b/tests/unit/physics/reentrancy.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/physics/reentrancy.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/physics/runtime_reload.cpp
+++ b/tests/unit/physics/runtime_reload.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/physics/runtime_reload.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/physics/solver.cpp
+++ b/tests/unit/physics/solver.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/physics/solver.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/physics/substep_policy.cpp
+++ b/tests/unit/physics/substep_policy.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/physics/substep_policy.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/protocol/json_codec.cpp
+++ b/tests/unit/protocol/json_codec.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/protocol/json_codec.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/protocol/json_codec_parse.cpp
+++ b/tests/unit/protocol/json_codec_parse.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/protocol/json_codec_parse.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/protocol/json_codec_parse_edge_cases.cpp
+++ b/tests/unit/protocol/json_codec_parse_edge_cases.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/protocol/json_codec_parse_edge_cases.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/ui/qt_mainwindow_controller.cpp
+++ b/tests/unit/ui/qt_mainwindow_controller.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/ui/qt_mainwindow_controller.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/ui/qt_mainwindow_presenter.cpp
+++ b/tests/unit/ui/qt_mainwindow_presenter.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/ui/qt_mainwindow_presenter.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/ui/qt_octree_overlay.cpp
+++ b/tests/unit/ui/qt_octree_overlay.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/ui/qt_octree_overlay.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/ui/qt_throughput_advisor.cpp
+++ b/tests/unit/ui/qt_throughput_advisor.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/ui/qt_throughput_advisor.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */

--- a/tests/unit/ui/qt_workspace_layout_store.cpp
+++ b/tests/unit/ui/qt_workspace_layout_store.cpp
@@ -1,6 +1,6 @@
 /*
  * @file tests/unit/ui/qt_workspace_layout_store.cpp
- * @author BLITZAR Contributors
+ * @author Luis1454
  * @project BLITZAR
  * @brief Automated verification assets for BLITZAR quality gates.
  */


### PR DESCRIPTION
Restores the repository owner references removed by PR #434. The prohibited product label remains absent.\n\nValidation:\n- product-label scan: no matches\n- git diff --check\n- python3 -m compileall -q tests/checks/suites/core/test_coverage_publication.py python_tools/ci/gpu_runner_inventory.py